### PR TITLE
Add Croatian Language

### DIFF
--- a/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
+++ b/src/Umbraco.Core/EmbeddedResources/Lang/hr.xml
@@ -1,0 +1,2829 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language alias="hr" intName="Croatian" localName="Hrvatski" lcid="1050" culture="hr-HR">
+  <creator>
+    <name>alevak09</name>
+    <link>https://github.com/alevak09</link>
+  </creator>
+  <area alias="actions">
+    <key alias="assigndomain">Kultura i imena hostova</key>
+    <key alias="auditTrail">Audit zapis</key>
+    <key alias="browse">Pregledaj čvor</key>
+    <key alias="changeDocType">Promijeni Tip Dokumenta</key>
+    <key alias="copy">Kopiraj</key>
+    <key alias="create">Kreiraj</key>
+    <key alias="export">Izvezi</key>
+    <key alias="createPackage">Kreiraj Paket</key>
+    <key alias="createGroup">Kreiraj grupu</key>
+    <key alias="delete">Obriši</key>
+    <key alias="disable">Onemogući</key>
+    <key alias="editSettings">Uredi postavke</key>
+    <key alias="emptyrecyclebin">Isprazni koš za smeće</key>
+    <key alias="enable">Omogući</key>
+    <key alias="exportDocumentType">Izvezi Tip Dokumenta</key>
+    <key alias="importdocumenttype">Uvezi Tip Dokumenta</key>
+    <key alias="importPackage">Uvezi Paket</key>
+    <key alias="liveEdit">Uređivanje na stranici</key>
+    <key alias="logout">Izlaz</key>
+    <key alias="move">Premjesti</key>
+    <key alias="notify">Obavijesti</key>
+    <key alias="protect">Javni pristup</key>
+    <key alias="publish">Objavi</key>
+    <key alias="unpublish">Poništi objavu</key>
+    <key alias="refreshNode">Osvježi</key>
+    <key alias="republish">Ponovna objava cijele stranice</key>
+    <key alias="remove">Ukloni</key>
+    <key alias="rename" version="7.3.0">Preimenuj</key>
+    <key alias="restore" version="7.3.0">Vrati</key>
+    <key alias="chooseWhereToCopy">Odaberite gdje ćete kopirati</key>
+    <key alias="chooseWhereToMove">Odaberite gdje ćete premjestiti</key>
+    <key alias="chooseWhereToImport">Odaberite gdje ćete uvesti</key>
+    <key alias="toInTheTreeStructureBelow">do u strukturi stabla ispod</key>
+    <key alias="infiniteEditorChooseWhereToCopy">Odaberite gdje želite kopirati odabrane stavke</key>
+    <key alias="infiniteEditorChooseWhereToMove">Odaberite gdje želite premjestiti odabrane stavke</key>
+    <key alias="wasMovedTo">je premješteno u</key>
+    <key alias="wasCopiedTo">je kopirana u</key>
+    <key alias="wasDeleted">je obrisana</key>
+    <key alias="rights">Dozvole</key>
+    <key alias="rollback">Vraćanje unazad</key>
+    <key alias="sendtopublish">Pošalji na objavljivanje</key>
+    <key alias="sendToTranslate">Pošalji na prijevod</key>
+    <key alias="setGroup">Postavi grupu</key>
+    <key alias="sort">Sortiraj</key>
+    <key alias="translate">Prevedi</key>
+    <key alias="update">Ažuriraj</key>
+    <key alias="setPermissions">Postavi dozvole</key>
+    <key alias="unlock">Otključaj</key>
+    <key alias="createblueprint">Kreirajte Predložak Sadržaja</key>
+    <key alias="resendInvite">Ponovo pošaljite pozivnicu</key>
+  </area>
+  <area alias="actionCategories">
+    <key alias="content">Sadržaj</key>
+    <key alias="administration">Administracija</key>
+    <key alias="structure">Struktura</key>
+    <key alias="other">Ostalo</key>
+  </area>
+  <area alias="actionDescriptions">
+    <key alias="assignDomain">Dopustite pristup za dodjelu kulture i imena hostova</key>
+    <key alias="auditTrail">Dopustite pristup za pregled dnevnika povijesti čvora</key>
+    <key alias="browse">Dopustite pristup za pregled čvora</key>
+    <key alias="changeDocType">Dopustite pristup za promjenu Tipa Dokumenta za čvor</key>
+    <key alias="copy">Dopustite pristup za kopiranje čvora</key>
+    <key alias="create">Dopustite pristup za kreiranje čvora</key>
+    <key alias="delete">Dopustite pristup za brisanje čvora</key>
+    <key alias="move">Dopustite pristup za premještaj čvora</key>
+    <key alias="protect">Dopustite pristup za postavljanje i promjenu javnog pristupa za čvor</key>
+    <key alias="publish">Dopustite pristup za objavljivanje čvora</key>
+    <key alias="unpublish">Dopustite pristup da poništavanje objave čvora</key>
+    <key alias="rights">Dopustite pristup za promjenu dozvola za čvor</key>
+    <key alias="rollback">Dopustite pristup za vraćanje čvora na prethodno stanje</key>
+    <key alias="sendtopublish">Dopustite pristup za slanje čvora na odobrenje prije objavljivanja</key>
+    <key alias="sendToTranslate">Dopustite pristup za slanje čvora na prijevod</key>
+    <key alias="sort">Dopustite pristup za promjenu sortiranja čvorova</key>
+    <key alias="translate">Dopustite pristup za prevođenje čvora</key>
+    <key alias="update">Dopustite pristup za spremanje čvora</key>
+    <key alias="createblueprint">Dopustite pristup za kreiranje Predloška Sadržaja</key>
+    <key alias="notify">Dopustite pristup za podešavanje obavijesti za čvorove</key>
+  </area>
+  <area alias="apps">
+    <key alias="umbContent">Sadržaj</key>
+    <key alias="umbInfo">Info</key>
+  </area>
+  <area alias="assignDomain">
+    <key alias="permissionDenied">Dozvola odbijena.</key>
+    <key alias="addNew">Dodaj novu domenu</key>
+    <key alias="addCurrent">Dodaj postojeću domenu</key>
+    <key alias="remove">Ukloni</key>
+    <key alias="invalidNode">Nevažeći čvor.</key>
+    <key alias="invalidDomain">Jedna ili više domena imaju nevažeći format.</key>
+    <key alias="duplicateDomain">Domena je već dodijeljena.</key>
+    <key alias="language">Jezik</key>
+    <key alias="domain">Domena</key>
+    <key alias="domainCreated">Nova domena '%0%' je kreirana</key>
+    <key alias="domainDeleted">Domena '%0%' je obrisana</key>
+    <key alias="domainExists">Domena '%0%' je već dodijeljena</key>
+    <key alias="domainUpdated">Domena '%0%' je ažurirana</key>
+    <key alias="orEdit">Uredi trenutne domene</key>
+    <key alias="domainHelpWithVariants">
+      <![CDATA[Važeći nazivi domena su: "example.com", "www.example.com", "example.com:8080", ili "https://www.example.com/".
+     Nadalje, podržane su i poddomene prvog nivoa, npr. "example.com/en" ili "/en".]]></key>
+    <key alias="inherit">Naslijedi</key>
+    <key alias="setLanguage">Kultura</key>
+    <key alias="setLanguageHelp">
+      <![CDATA[Postavite kulturu za čvorove ispod trenutnog čvora,<br /> ili naslijedite kulturu od roditeljskih čvorova. Također će se primijeniti<br />
+      na trenutni čvor, osim ako se domena u nastavku ne primjenjuje.]]>
+    </key>
+    <key alias="setDomains">Domene</key>
+  </area>
+  <area alias="buttons">
+    <key alias="clearSelection">Obriši odabir</key>
+    <key alias="select">Odaberi</key>
+    <key alias="somethingElse">Uradi nešto drugo</key>
+    <key alias="bold">Podebljano</key>
+    <key alias="deindent">Odustani od uvlačenje odlomka</key>
+    <key alias="formFieldInsert">Umetni polje obrasca</key>
+    <key alias="graphicHeadline">Umetni grafički naslov</key>
+    <key alias="htmlEdit">Uredi Html</key>
+    <key alias="indent">Uvuci odlomak</key>
+    <key alias="italic">Nakošeno</key>
+    <key alias="justifyCenter">Centrirano</key>
+    <key alias="justifyLeft">Poravnanje lijevo</key>
+    <key alias="justifyRight">Poravnanje desno</key>
+    <key alias="linkInsert">Umetni link</key>
+    <key alias="linkLocal">Umetni lokalni link (sidro)</key>
+    <key alias="listBullet">Obična lista</key>
+    <key alias="listNumeric">Numerička lista</key>
+    <key alias="macroInsert">Umetni makro</key>
+    <key alias="pictureInsert">Umetni sliku</key>
+    <key alias="publishAndClose">Objavi i zatvori</key>
+    <key alias="publishDescendants">Objavi sa potomcima</key>
+    <key alias="relations">Uredite odnose</key>
+    <key alias="returnToList">Povratak na listu</key>
+    <key alias="save">Spremi</key>
+    <key alias="saveAndClose">Spremi i zatvori</key>
+    <key alias="saveAndPublish">Spremi i objavi</key>
+    <key alias="saveToPublish">Spremi i pošalji na odobrenje</key>
+    <key alias="saveListView">Spremi prikaz liste</key>
+    <key alias="schedulePublish">Zakazivanje objave</key>
+    <key alias="saveAndPreview">Spremi i pregledaj</key>
+    <key alias="showPageDisabled">Pregled je onemogućen jer nije dodijeljen predložak</key>
+    <key alias="styleChoose">Odaberi stil</key>
+    <key alias="styleShow">Prikaži stilove</key>
+    <key alias="tableInsert">Umetni tablicu</key>
+    <key alias="saveAndGenerateModels">Spremi i generiraj modele</key>
+    <key alias="undo">Poništi</key>
+    <key alias="redo">Vrati</key>
+    <key alias="deleteTag">Obriši tag</key>
+    <key alias="confirmActionCancel">Odustani</key>
+    <key alias="confirmActionConfirm">Potvrdi</key>
+    <key alias="morePublishingOptions">Više opcija za objavljivanje</key>
+    <key alias="submitChanges">Pošalji</key>
+  </area>
+  <area alias="auditTrails">
+    <key alias="atViewingFor">Pregled za</key>
+    <key alias="delete">Sadržaj je obrisan</key>
+    <key alias="unpublish">Poništena objava Sadržaja</key>
+    <key alias="unpublishvariant">Poništena je objava sadržaja za jezike: %0% </key>
+    <key alias="publish">Sadržaj je spremljen i objavljen</key>
+    <key alias="publishvariant">Sadržaj spremljen i objavljen za jezike: %0%</key>
+    <key alias="save">Sadržaj spremljen</key>
+    <key alias="savevariant">Sadržaj spremljen za jezike: %0%</key>
+    <key alias="move">Sadržaj premješten</key>
+    <key alias="copy">Sadržaj kopiran</key>
+    <key alias="rollback">Sadržaj vraćen</key>
+    <key alias="sendtopublish">Sadržaj poslan na objavljivanje</key>
+    <key alias="sendtopublishvariant">Sadržaj poslan na objavljivanje za jezike: %0%</key>
+    <key alias="sort">Sortiranje podređenih stavki je izvršio korisnik</key>
+    <key alias="custom">%0%</key>
+    <key alias="contentversionpreventcleanup">Čišćenje je onemogućeno za verziju: %0%</key>
+    <key alias="contentversionenablecleanup">Čišćenje je omogućeno za verziju: %0%</key>
+    <key alias="smallCopy">Kopiraj</key>
+    <key alias="smallPublish">Objavljeno</key>
+    <key alias="smallPublishVariant">Objavi</key>
+    <key alias="smallMove">Premjesti</key>
+    <key alias="smallSave">Spremljeno</key>
+    <key alias="smallSaveVariant">Spremi</key>
+    <key alias="smallDelete">Obriši</key>
+    <key alias="smallUnpublish">Poništi objavu</key>
+    <key alias="smallRollBack">Vrati na stariju verziju</key>
+    <key alias="smallSendToPublish">Pošalji na objavljivanje</key>
+    <key alias="smallSendToPublishVariant">Pošalji na objavljivanje</key>
+    <key alias="smallSort">Sortiraj</key>
+    <key alias="smallCustom">Prilagođeno</key>
+    <key alias="smallContentVersionPreventCleanup">Spremi</key>
+    <key alias="smallContentVersionEnableCleanup">Spremi</key>
+    <key alias="historyIncludingVariants">Povijest (sve varijante)</key>
+  </area>
+  <area alias="codefile">
+    <key alias="createFolderIllegalChars">Naziv mape ne može sadržavati nedozvoljene znakove.</key>
+    <key alias="deleteItemFailed">Nije uspjelo brisanje stavke: %0%</key>
+  </area>
+  <area alias="content">
+    <key alias="isPublished" version="7.2">Da li je objavljeno</key>
+    <key alias="about">Više o ovoj stranici</key>
+    <key alias="alias">Alias</key>
+    <key alias="alternativeTextHelp">(kako bi opisali sliku preko telefona)</key>
+    <key alias="alternativeUrls">Alternativni linkovi</key>
+    <key alias="clickToEdit">Kliknite za uređivanje ove stavke</key>
+    <key alias="createBy">Kreirao</key>
+    <key alias="createByDesc" version="7.0">Originalni autor</key>
+    <key alias="updatedBy" version="7.0">Ažurirao</key>
+    <key alias="createDate">Kreirano</key>
+    <key alias="createDateDesc" version="7.0">Datum i vrijeme kreiranja ovog dokumenta</key>
+    <key alias="documentType">Tip dokumenta</key>
+    <key alias="editing">Uređivanje</key>
+    <key alias="expireDate">Ukloni na</key>
+    <key alias="itemChanged">Ova stavka je promijenjena nakon objavljivanja</key>
+    <key alias="itemNotPublished">Ova stavka nije objavljena</key>
+    <key alias="lastPublished">Posljednje objavljeno</key>
+    <key alias="noItemsToShow">Nema stavki za prikaz</key>
+    <key alias="listViewNoItems" version="7.1.5">Nema stavki za prikaz na listi.</key>
+    <key alias="listViewNoContent">Nije dodan sadržaj</key>
+    <key alias="listViewNoMembers">Nijedan član nije dodan</key>
+    <key alias="mediatype">Tip medija</key>
+    <key alias="mediaLinks">Link do medijske stavke</key>
+    <key alias="membergroup">Grupa članova</key>
+    <key alias="memberrole">Uloga</key>
+    <key alias="membertype">Tip člana</key>
+    <key alias="noChanges">Nisu napravljene nikakve promjene</key>
+    <key alias="noDate">Nije odabran datum</key>
+    <key alias="nodeName">Naslov stranice</key>
+    <key alias="noMediaLink">Ova medijska stavka nema vezu</key>
+    <key alias="otherElements">Svojstva</key>
+    <key alias="parentNotPublished">Ovaj dokument je objavljen, ali nije vidljiv jer nadređeni '%0%' nije objavljen</key>
+    <key alias="parentCultureNotPublished">Ova kultura je objavljena, ali nije vidljiva jer nije objavljena na nadređenom '%0%'</key>
+    <key alias="parentNotPublishedAnomaly">Ovaj dokument je objavljen, ali nije u predmemoriji</key>
+    <key alias="getUrlException">Nije moguće dohvatiti URL</key>
+    <key alias="routeError">Ovaj dokument je objavljen, ali njegov URL je u sukobu sa sadržajem %0%</key>
+    <key alias="routeErrorCannotRoute">Ovaj dokument je objavljen, ali njegov URL se ne može preusmjeriti</key>
+    <key alias="publish">Objavi</key>
+    <key alias="published">Objavljeno</key>
+    <key alias="publishedPendingChanges">Objavljeno (promjene na čekanju)</key>
+    <key alias="publishStatus">Status objave</key>
+    <key alias="publishDescendantsHelp">
+      <![CDATA[Objavi <strong>%0%</strong> i sve stavke sadržaja ispod i time čineći njihov sadržaj javno dostupnim.]]></key>
+    <key alias="publishDescendantsWithVariantsHelp">
+      <![CDATA[Objavi varijante i varijante istog tipa ispod i na taj način učinite njihov sadržaj javno dostupnim.]]></key>
+    <key alias="releaseDate">Objavi na</key>
+    <key alias="unpublishDate">Poništi objavu na</key>
+    <key alias="removeDate">Obriši datum</key>
+    <key alias="setDate">Postavi datum</key>
+    <key alias="sortDone">Sortiranje je ažurirano</key>
+    <key alias="sortHelp">Da biste sortirali čvorove, jednostavno pomaknite čvorove ili kliknite na jedno od zaglavlja kolona. Možete odabrati
+       više čvorova držeći tipku "shift" ili "control" dok birate
+    </key>
+    <key alias="statistics">Statistika</key>
+    <key alias="titleOptional">Naslov (opcionalno)</key>
+    <key alias="altTextOptional">Alternativni tekst (opcionalno)</key>
+    <key alias="captionTextOptional">Natpis (opcionalno)</key>
+    <key alias="type">Tip</key>
+    <key alias="unpublish">Poništi objavu</key>
+    <key alias="unpublished">Neobjavljeno</key>
+    <key alias="notCreated">Nije kreirano</key>
+    <key alias="updateDate">Zadnje uređivano</key>
+    <key alias="updateDateDesc" version="7.0">Datum/vrijeme uređivanja ovog dokumenta</key>
+    <key alias="uploadClear">Ukloni datoteke</key>
+    <key alias="uploadClearImageContext">Kliknite ovdje kako bi uklonili sliku iz medijske stavke</key>
+    <key alias="uploadClearFileContext">Kliknite ovdje kako bi uklonili datoteku iz medijske stavke</key>
+    <key alias="urls">Link na dokument</key>
+    <key alias="memberof">Član grupe</key>
+    <key alias="notmemberof">Nije član grupe</key>
+    <key alias="childItems" version="7.0">Dječje stavke</key>
+    <key alias="target" version="7.0">Meta</key>
+    <key alias="scheduledPublishServerTime">Ovo se označava kao sljedeće vrijeme na serveru:</key>
+    <key alias="scheduledPublishDocumentation">
+      <![CDATA[<a href="https://docs.umbraco.com/umbraco-cms/fundamentals/data/scheduled-publishing#timezones" target="_blank" rel="noopener">Što ovo znači?</a>]]></key>
+    <key alias="nestedContentDeleteItem">Jeste li sigurni da želite obrisati ovu stavku?</key>
+    <key alias="nestedContentEditorNotSupported">Svojstvo %0% koristi uređivač %1% koji nije podržan za Ugniježđeni
+      Sadržaj.
+    </key>
+    <key alias="nestedContentDeleteAllItems">Jeste li sigurni da želite obrisati sve stavke?</key>
+    <key alias="nestedContentNoContentTypes">Za ovo svojstvo nisu konfigurirani tipovi sadržaja.</key>
+    <key alias="nestedContentAddElementType">Dodajte tip elementa</key>
+    <key alias="nestedContentSelectElementTypeModalTitle">Odaberi tip elementa</key>
+    <key alias="nestedContentGroupHelpText">Odaberite grupu čija svojstva trebaju biti prikazana. Ako je ostavljeno prazno,
+       koristit će se prva grupa na tipu elementa.
+    </key>
+    <key alias="nestedContentTemplateHelpTextPart1">Unesite angular izraz za procjenu svake stavke za njeno
+       ime. Koristi
+    </key>
+    <key alias="nestedContentTemplateHelpTextPart2">za prikaz indeksa stavke</key>
+    <key alias="nestedContentNoGroups">Odabrani tip elementa ne sadrži nijednu podržanu grupu (ovaj uređivač ne podržava kartice, promijenite ih u grupe ili koristite uređivač liste blokova).</key>
+    <key alias="addTextBox">Dodajte još jedan okvir za tekst</key>
+    <key alias="removeTextBox">Uklonite ovaj okvir za tekst</key>
+    <key alias="contentRoot">Korijen Sadržaja</key>
+    <key alias="includeUnpublished">Uključite neobjavljeni sadržaj.</key>
+    <key alias="isSensitiveValue">Ova vrijednost je skrivena. Ako vam je potreban pristup da vidite ovu vrijednost, obratite se
+       administratoru web stranice.
+    </key>
+    <key alias="isSensitiveValue_short">Ova vrijednost je skrivena.</key>
+    <key alias="languagesToPublish">Koje jezike želite objaviti?</key>
+    <key alias="languagesToSendForApproval">Koje jezike želite poslati na odobrenje?</key>
+    <key alias="languagesToSchedule">Koje jezike želite zakazano objaviti?</key>
+    <key alias="languagesToUnpublish">Odaberite jezike za poništavanje objavljivanja. Poništavanje objavljivanja obaveznog jezika će
+       poništiti objavljivanje svih jezika.
+    </key>
+    <key alias="variantsWillBeSaved">Sve nove varijante će biti spremljene.</key>
+    <key alias="variantsToPublish">Koje varijante želite objaviti?</key>
+    <key alias="variantsToSave">Odaberite koje varijante želite spremiti.</key>
+    <key alias="publishRequiresVariants">Za objavljivanje su potrebne sljedeće varijante:</key>
+    <key alias="notReadyToPublish">Nije spremno za objavljivanje</key>
+    <key alias="readyToPublish">Spremno za objavljivanje?</key>
+    <key alias="readyToSave">Spremno za spremanje?</key>
+    <key alias="resetFocalPoint">Poništi fokusnu točku</key>
+    <key alias="sendForApproval">Pošalji na odobrenje</key>
+    <key alias="schedulePublishHelp">Odaberite datum i vrijeme za objavljivanje i/ili poništavanje objave stavke sadržaja.</key>
+    <key alias="createEmpty">Kreiraj novo</key>
+    <key alias="createFromClipboard">Zalijepi iz međuspremnika</key>
+    <key alias="nodeIsInTrash">Ova stavka je u košu za smeće</key>
+  </area>
+  <area alias="blueprints">
+    <key alias="createBlueprintFrom"><![CDATA[Kreirajte novi predložak sadržaja iz <em>%0%</em>]]></key>
+    <key alias="blankBlueprint">Prazno</key>
+    <key alias="selectBlueprint">Odaberite predložak sadržaja</key>
+    <key alias="createdBlueprintHeading">Predložak sadržaja kreiran</key>
+    <key alias="createdBlueprintMessage">Predložak sadržaja je kreiran od '%0%'</key>
+    <key alias="duplicateBlueprintMessage">Drugi predložak sadržaja sa istim nazivom već postoji</key>
+    <key alias="blueprintDescription">Predložak sadržaja je unaprijed definiran sadržaj koji uređivač može odabrati da bi se koristio
+       kao osnova za kreiranje novog sadržaja
+    </key>
+  </area>
+  <area alias="media">
+    <key alias="clickToUpload">Kliknite za prijenos</key>
+    <key alias="orClickHereToUpload">ili kliknite ovdje kako bi odaberali datoteke</key>
+    <key alias="disallowedFileType">Nije moguće učitati ovu datoteku, jer nema odobreni tip datoteke</key>
+    <key alias="disallowedMediaType">Nije moguće učitati ovu datoteku, format medija sa nastavkom '%0%' nije dozvoljen</key>
+    <key alias="invalidFileName">Nije moguće učitati ovu datoteku, jer nema važeći naziv datoteke</key>
+    <key alias="maxFileSize">Maksimalna veličina datoteke je</key>
+    <key alias="mediaRoot">Korijen medija</key>
+    <key alias="createFolderFailed">Kreiranje mape pod ID-om roditelja nije uspjelo %0%</key>
+    <key alias="renameFolderFailed">Preimenovanje mape sa ID-om %0% nije uspjelo</key>
+    <key alias="dragAndDropYourFilesIntoTheArea">Povucite i ispustite svoje datoteke u područje</key>
+  </area>
+  <area alias="member">
+    <key alias="createNewMember">Kreirajte novog člana</key>
+    <key alias="allMembers">Svi članovi</key>
+    <key alias="memberGroupNoProperties">Grupe članova nemaju dodatnih svojstva za uređivanje.</key>
+    <key alias="2fa">Dvostruka provjera autentičnosti</key>
+  </area>
+  <area alias="contentType">
+    <key alias="copyFailed">Kopiranje tipa sadržaja nije uspjelo</key>
+    <key alias="moveFailed">Premještanje tipa sadržaja nije uspjelo</key>
+  </area>
+  <area alias="mediaType">
+    <key alias="copyFailed">Kopiranje tipa medija nije uspjelo</key>
+    <key alias="moveFailed">Premještanje tipa medija nije uspjelo</key>
+    <key alias="autoPickMediaType">Automatski odabir</key>
+  </area>
+  <area alias="memberType">
+    <key alias="copyFailed">Kopiranje tipa člana nije uspjelo</key>
+  </area>
+  <area alias="create">
+    <key alias="chooseNode">Gdje želite kreirati novi %0%</key>
+    <key alias="createUnder">Kreirajte stavku pod</key>
+    <key alias="createContentBlueprint">Odaberite vrstu dokumenta za koju želite napraviti predložak sadržaja</key>
+    <key alias="enterFolderName">Unesite naziv mape</key>
+    <key alias="updateData">Odaberite vrstu i naslov</key>
+    <key alias="noDocumentTypes" version="7.0">
+      <![CDATA[Nema dozvoljenih tipova dokumenata dostupnih za kreiranje sadržaja ovdje. Morate ih omogućiti u <strong>Dokument Tip</strong> unutar sekcije <strong>Postavke</strong>, uređivanjem <strong>Dozvoljeni tipovi podređenih čvorova</strong> unutar <strong>Dozvole</strong>.]]></key>
+    <key alias="noDocumentTypesAtRoot">
+      <![CDATA[Nema dozvoljenih tipova dokumenata dostupnih za kreiranje sadržaja ovdje. Morate ih kreirati u <strong>Dokument Tip</strong> unutar sekcije <strong>Postavke</strong>.]]></key>
+    <key alias="noDocumentTypesWithNoSettingsAccess">Odabrana stranica u stablu sadržaja ne dozvoljava kreiranje nijedne stranice ispod.
+    </key>
+    <key alias="noDocumentTypesEditPermissions">Uredi dozvole za ovaj tip dokumenta</key>
+    <key alias="noDocumentTypesCreateNew">Kreiraj novi tip dokumenta</key>
+    <key alias="noDocumentTypesAllowedAtRoot">
+      <![CDATA[Nema dozvoljenih tipova dokumenata dostupnih za kreiranje sadržaja ovdje. Morate ih omogućiti u <strong>Dokument Tip</strong> unutar sekcije <strong>Postavke</strong>, izmjenom <strong>Dozvoli kao root</strong> opcije unutar <strong>Dozvole</strong>.]]></key>
+    <key alias="noMediaTypes" version="7.0">
+      <![CDATA[Nema dozvoljenih tipova medija dostupnih za kreiranje medija ovdje. Morate ih omogućiti u <strong>Media Tip</strong> unutar sekcije <strong>Postavke</strong>, uređivanjem <strong>Dozvoljeni tipovi podređenih čvorova</strong> unutar <strong>Dozvole</strong>.]]></key>
+    <key alias="noMediaTypesWithNoSettingsAccess">Odabrani medij u stablu ne dopušta bilo koji drugi medij
+       kreiran ispod njega.
+    </key>
+    <key alias="noMediaTypesEditPermissions">Uredi dozvole za ovaj tip medija</key>
+    <key alias="documentTypeWithoutTemplate">Tip dokumenta bez predloška</key>
+    <key alias="documentTypeWithTemplate">Tip dokumenta sa predloškom</key>
+    <key alias="documentTypeWithTemplateDescription">Definiranje podataka za stranicu sadržaja koja se može kreirati u stablu sadržaja i direktno je dostupana preko URL-a.
+    </key>
+    <key alias="documentType">Tip dokumenta</key>
+    <key alias="documentTypeDescription">Definiranje podataka za komponentu sadržaja koju mogu kreirati urednici u
+       stablu sadržaja i može biti izabrana na drugim stranicama, ali nema direktan URL.
+    </key>
+    <key alias="elementType">Tip elementa</key>
+    <key alias="elementTypeDescription">Definiranje sheme za ponavljajući skup svojstava, na primjer, u 'Bloku
+       Uređivaču svojstava Lista' ili 'Ugniježđeni sadržaj'.
+    </key>
+    <key alias="composition">Kompozicija</key>
+    <key alias="compositionDescription">Definiranje višenamjenski skup svojstava koja se mogu uključiti u definiciju
+       više drugih vrsta dokumenata. Na primjer, skup 'Common Page Settings'.
+    </key>
+    <key alias="folder">Mapa</key>
+    <key alias="folderDescription">Koristi se za organiziranje tipova dokumenata, sastava i tipova elemenata kreiranih u ovome
+       Stablo vrste dokumenta.
+    </key>
+    <key alias="newFolder">Nova mapa</key>
+    <key alias="newDataType">Novi tip podatka</key>
+    <key alias="newJavascriptFile">Nova JavaScript datoteka</key>
+    <key alias="newEmptyPartialView">Novi prazan djelomični prikaz</key>
+    <key alias="newPartialViewMacro">Novi djelomični prikaz za makro</key>
+    <key alias="newPartialViewFromSnippet">Novi djelomični prikaz iz isječka</key>
+    <key alias="newPartialViewMacroFromSnippet">Novi djelomični prikaz za makro iz isječka</key>
+    <key alias="newPartialViewMacroNoMacro">Novi djelomični prikaz za makro (bez makroa)</key>
+    <key alias="newStyleSheetFile">Nova CSS datoteka</key>
+    <key alias="newRteStyleSheetFile">Nova Rich Text Editor CSS datoteka</key>
+  </area>
+  <area alias="dashboard">
+    <key alias="browser">Pregledajte svoju web stranicu</key>
+    <key alias="dontShowAgain">- Sakrij</key>
+    <key alias="nothinghappens">Ako se Umbraco ne otvara, možda ćete morati dozvoliti skočne prozore sa ove stranice</key>
+    <key alias="openinnew">je otvoren u novom prozoru</key>
+    <key alias="restart">Ponovno pokreni</key>
+    <key alias="visit">Posjetite</key>
+    <key alias="welcome">Dobrodošli</key>
+  </area>
+  <area alias="prompt">
+    <key alias="stay">Ostani</key>
+    <key alias="discardChanges">Poništite promjene</key>
+    <key alias="unsavedChanges">Imate ne spremljene promjene</key>
+    <key alias="unsavedChangesWarning">Jeste li sigurni da želite izaći s ove stranice? - imate ne spremljene promjene</key>
+    <key alias="confirmListViewPublish">Objavljivanjem će odabrane stavke biti vidljive na stranici.</key>
+    <key alias="confirmListViewUnpublish">Poništavanje objavljivanja će ukloniti odabrane stavke i sve njihove potomke sa
+       stranice.
+    </key>
+    <key alias="confirmUnpublish">Poništavanje objavljivanja će ukloniti ovu stranicu i sve njene potomke sa stranice.</key>
+    <key alias="doctypeChangeWarning">Imate ne spremljene promjene. Promjenom vrste dokumenta odbacit će se promjene.</key>
+  </area>
+  <area alias="bulk">
+    <key alias="done">Završeno</key>
+    <key alias="deletedItem">Obrisana %0% stavka</key>
+    <key alias="deletedItems">Obrisano %0% stavki</key>
+    <key alias="deletedItemOfItem">Obrisana %0% od %1% stavka</key>
+    <key alias="deletedItemOfItems">Obrisano %0% od %1% stavki</key>
+    <key alias="publishedItem">Objavljeno %0% stavka</key>
+    <key alias="publishedItems">Objavljeno %0% stavki</key>
+    <key alias="publishedItemOfItem">Objavljeno %0% od %1% stavka</key>
+    <key alias="publishedItemOfItems">Objavljeno %0% od %1% stavki</key>
+    <key alias="unpublishedItem">Neobjavljeno za %0% stavku</key>
+    <key alias="unpublishedItems">Neobjavljeno za %0% stavki</key>
+    <key alias="unpublishedItemOfItem">Neobjavljeno za %0% od %1% stavku</key>
+    <key alias="unpublishedItemOfItems">Neobjavljeno za %0% od %1% stavki</key>
+    <key alias="movedItem">Premještena %0% stavka</key>
+    <key alias="movedItems">Premješteno %0% stavki</key>
+    <key alias="movedItemOfItem">Premješteno %0% od %1% stavku</key>
+    <key alias="movedItemOfItems">Premješteno %0% od %1% stavki</key>
+    <key alias="copiedItem">Kopirana %0% stavka</key>
+    <key alias="copiedItems">Kopirano %0% stavki</key>
+    <key alias="copiedItemOfItem">Kopirano %0% od %1% stavku</key>
+    <key alias="copiedItemOfItems">Kopirano %0% od %1% stavki</key>
+  </area>
+  <area alias="defaultdialogs">
+    <key alias="nodeNameLinkPicker">Naslov linka</key>
+    <key alias="urlLinkPicker">Link</key>
+    <key alias="anchorLinkPicker">Sidro / querystring</key>
+    <key alias="anchorInsert">Naziv</key>
+    <key alias="assignDomain">Upravljanje nazivima domena</key>
+    <key alias="closeThisWindow">Zatvorite ovaj prozor</key>
+    <key alias="confirmdelete">Jeste li sigurni da želite obrisati</key>
+    <key alias="confirmdeleteNumberOfItems"><![CDATA[Jeste li sigurni da želite obrisati <strong>%0%</strong> od <strong>%1%</strong> stavki]]></key>
+    <key alias="confirmdisable">Jeste li sigurni da želite onemogućiti</key>
+    <key alias="confirmremove">Jeste li sigurni da želite ukloniti</key>
+    <key alias="confirmremoveusageof"><![CDATA[Jeste li sigurni da želite ukloniti korištenje <strong>%0%</strong>]]></key>
+    <key alias="confirmlogout">Jeste li sigurni?</key>
+    <key alias="confirmSure">Jeste li sigurni?</key>
+    <key alias="cut">Izreži</key>
+    <key alias="editdictionary">Uredi stavku iz rječnika</key>
+    <key alias="editlanguage">Uredi jezik</key>
+    <key alias="editSelectedMedia">Uredite odabrane medije</key>
+    <key alias="insertAnchor">Umetni lokalnu vezu</key>
+    <key alias="insertCharacter">Umetni znak</key>
+    <key alias="insertgraphicheadline">Umetni grafički naslov</key>
+    <key alias="insertimage">Umetni sliku</key>
+    <key alias="insertlink">Umetni link</key>
+    <key alias="insertMacro">Klikni za dodavanje makro</key>
+    <key alias="inserttable">Umetni tablicu</key>
+    <key alias="languagedeletewarning">Ovo će obrisati jezik</key>
+    <key alias="languageChangeWarning">Promjena kulture jezika može biti skupa operacija i rezultirat će promjenama u predmemoriji sadržaja i indeksima koji se rekonstruiraju
+    </key>
+    <key alias="lastEdited">Zadnje uređivano</key>
+    <key alias="link">Link</key>
+    <key alias="linkinternal">Interni link:</key>
+    <key alias="linklocaltip">Kada koristite lokalni linkovi, umetnite "#" ispred linka</key>
+    <key alias="linknewwindow">Otvoriti u novom prozoru?</key>
+    <key alias="macroDoesNotHaveProperties">Ovaj makro ne sadrži svojstva koja možete uređivati</key>
+    <key alias="paste">Zalijepi</key>
+    <key alias="permissionsEdit">Uredi dozvole za</key>
+    <key alias="permissionsSet">Postavi dozvole za</key>
+    <key alias="permissionsSetForGroup">Postavi dozvole za %0% za grupu korisnika %1%</key>
+    <key alias="permissionsHelp">Odaberi grupe korisnika za koje želite postaviti dozvole</key>
+    <key alias="recycleBinDeleting">Stavke u košu za smeće se upravo brišu. Molimo vas da ne zatvarate ovaj prozor
+       dok se ova operacija odvija
+    </key>
+    <key alias="recycleBinIsEmpty">Koš za smeće je sada prazna</key>
+    <key alias="recycleBinWarning">Kada se stavke obrišu iz koša za smeće, nestat će zauvijek</key>
+    <key alias="regexSearchError">
+      <![CDATA[<a target='_blank' rel='noopener' href='http://regexlib.com'>regexlib.com</a> web servis trenutno ima probleme u komunikaciji na koje ne možemo utjecati. Žao nam je zbog nastalih smetnji.]]></key>
+    <key alias="regexSearchHelp">Traži regular expression kako bi njime validirali polje unosa. Primjer: 'e-pošta,
+       'poštanski broj', 'URL'.
+    </key>
+    <key alias="removeMacro">Ukloni makro</key>
+    <key alias="requiredField">Obavezno polje</key>
+    <key alias="sitereindexed">Stranica je ponovo indeksirana</key>
+    <key alias="siterepublished">Predmemorija web stranice je osvježena. Sav objavljeni sadržaj je sada ažuriran. Dok će sav
+		neobjavljen sadržaj ostati neobjavljen
+    </key>
+    <key alias="siterepublishHelp">Predmemorija web stranice će biti osvježena. Svi objavljeni sadržaji bit će ažurirani, dok će sav
+       neobjavljeni sadržaj ostati neobjavljen.
+    </key>
+    <key alias="tableColumns">Broj kolona</key>
+    <key alias="tableRows">Broj redova</key>
+    <key alias="thumbnailimageclickfororiginal">Klikni na sliku za prikaz pune veličine</key>
+    <key alias="treepicker">Odaberi stavku</key>
+    <key alias="viewCacheItem">Prikaži stavku predmemorije</key>
+    <key alias="relateToOriginalLabel">Odnosi se na original</key>
+    <key alias="includeDescendants">Uključiti potomke</key>
+    <key alias="theFriendliestCommunity">Prijateljska zajednica</key>
+    <key alias="linkToPage">Link na stranicu</key>
+    <key alias="openInNewWindow">Otvara povezani dokument u novom prozoru ili kartici</key>
+    <key alias="linkToMedia">Link do medija</key>
+    <key alias="selectContentStartNode">Odaberi početni čvor sadržaja</key>
+    <key alias="selectMedia">Odaberi medije</key>
+    <key alias="selectMediaType">Odaberi tip medija</key>
+    <key alias="selectIcon">Odaberi ikonu</key>
+    <key alias="selectItem">Odaberi stavku</key>
+    <key alias="selectLink">Odaberi vezu</key>
+    <key alias="selectMacro">Odaberi makro</key>
+    <key alias="selectContent">Odaberi sadržaj</key>
+    <key alias="selectContentType">Odaberi tip sadržaja</key>
+    <key alias="selectMediaStartNode">Odaberi početni čvor medija</key>
+    <key alias="selectMember">Odaberi člana</key>
+    <key alias="selectMemberGroup">Odaberi grupu članova</key>
+    <key alias="selectMemberType">Odaberi tip članova</key>
+    <key alias="selectNode">Odaberi čvor</key>
+    <key alias="selectLanguages">Odaberi jezike</key>
+    <key alias="selectSections">Odaberi sekcije</key>
+    <key alias="selectUser">Odaberi korisnika</key>
+    <key alias="selectUsers">Odaberi korisnike</key>
+    <key alias="noIconsFound">Nema pronađenih ikona</key>
+    <key alias="noMacroParams">Nema parametara za ovaj makro</key>
+    <key alias="noMacros">Nema dostupnih makroa za umetanje</key>
+    <key alias="externalLoginProviders">Vanjski provajderi prijave</key>
+    <key alias="exceptionDetail">Detalji iznimaka</key>
+    <key alias="stacktrace">Zapisnik</key>
+    <key alias="innerException">Unutarnja iznimka</key>
+    <key alias="linkYour">Poveži svoj</key>
+    <key alias="unLinkYour">Poništi povezivanje svoje veze</key>
+    <key alias="account">račun</key>
+    <key alias="selectEditor">Odaberi urednika</key>
+    <key alias="selectSnippet">Odaberite predložak</key>
+    <key alias="variantdeletewarning">Ovo će obrisati čvor i sve njegove jezike. Ako želite obrisati jedan jezik, poništite radije objavu na tom jeziku.</key>
+    <key alias="propertyuserpickerremovewarning"><![CDATA[Ovo će ukloniti korisnika <strong>%0%</strong>.]]></key>
+    <key alias="userremovewarning"><![CDATA[Ovo će ukloniti korisnika <strong>%0%</strong> iz grupe <strong>%1%</strong>]]></key>
+    <key alias="yesRemove">Da, ukloni</key>
+    <key alias="deleteLayout">Brišete izgled</key>
+    <key alias="deletingALayout">Promjena izgleda će rezultirati gubitkom podataka za bilo koji postojeći sadržaj koji je zasnovan na ovoj konfiguraciji.</key>
+  </area>
+  <area alias="dictionary">
+    <key alias="importDictionaryItemHelp">
+      Da bi uvezli stavku iz rječnika, pronađite ".udt" datoteku na svom računalu klikom na
+       gumb "Uvezi" (na sljedećem ekranu će se tražiti da potvrdite)
+    </key>
+    <key alias="itemDoesNotExists">Stavka iz rječnika ne postoji.</key>
+    <key alias="parentDoesNotExists">Nadređena stavka ne postoji.</key>
+    <key alias="noItems">Ne postoje stavke iz rječnika.</key>
+    <key alias="noItemsInFile">U ovoj datoteci nema stavki iz rječnika.</key>
+    <key alias="noItemsFound">Nisu pronađene stavke iz rječnika.</key>
+    <key alias="createNew">Kreirajte stavku iz rječnika</key>
+  </area>
+  <area alias="dictionaryItem">
+    <key alias="description"><![CDATA[
+      Uredite različite jezičke varijante za stavku rječnika '<em>%0%</em>' ispod
+   ]]>    </key>
+    <key alias="displayName">Kultura</key>
+    <key alias="changeKeyError"><![CDATA[
+      Stavka '%0%' već postoji.
+   ]]>    </key>
+    <key alias="overviewTitle">Pregled riječnika</key>
+  </area>
+  <area alias="examineManagement">
+    <key alias="configuredSearchers">Konfigurirani pretraživači</key>
+    <key alias="configuredSearchersDescription">Prikazuje svojstva i alate za bilo koji konfigurirani pretraživač (npr. kao multi-indeksni pretraživač)</key>
+    <key alias="fieldValues">Vrijednosti polja</key>
+    <key alias="healthStatus">Status zdravlja</key>
+    <key alias="healthStatusDescription">Status zdravlja indeksa i da li se može pročitati</key>
+    <key alias="indexers">Indeksi</key>
+    <key alias="indexInfo">Indeks info</key>
+    <key alias="contentInIndex">Sadržaj u indeksu</key>
+    <key alias="indexInfoDescription">Navodi svojstva indeksa</key>
+    <key alias="manageIndexes">Upravljanje Examine-ovim indeksima</key>
+    <key alias="manageIndexesDescription">Omogućava vam pregled detalja svakog indeksa i pruža neke alate za upravljanje indeksima</key>
+    <key alias="rebuildIndex">Obnovi indeks</key>
+    <key alias="rebuildIndexWarning"><![CDATA[
+      Ovo će uzrokovati obnavljanje indexa.<br />
+      Ovisno o količini sadržaja vaše web stranice, ovo bi moglo potrajati.<br />
+      Nije preporučljivo obnavljati index-e tijekom velike posjećenosti vaše web stranice ili u vrijeme kada urednik uređuje sadržaj stranice.
+     ]]>
+    </key>
+    <key alias="searchers">Pretraživači</key>
+    <key alias="searchDescription">Pretražite indeks i pogledajte rezultate</key>
+    <key alias="tools">Alati</key>
+    <key alias="toolsDescription">Alati za upravljanje indeksima</key>
+    <key alias="fields">polja</key>
+    <key alias="indexCannotRead">Indeks se ne može pročitati i morat će se ponovo obnoviti</key>
+    <key alias="processIsTakingLonger">Proces traje duže od očekivanog, provjerite Umbraco log zapis da vidite
+       da li je bilo grešaka tijekom ove operacije
+    </key>
+    <key alias="indexCannotRebuild">Ovaj indeks se ne može ponovo obnoviti jer mu nije dodijeljen</key>
+    <key alias="iIndexPopulator">IIndexPopulator</key>
+  </area>
+  <area alias="placeholders">
+    <key alias="username">Upišite svoje korisničko ime</key>
+    <key alias="password">Upišite svoju lozinku</key>
+    <key alias="confirmPassword">Potvrdite lozinku</key>
+    <key alias="nameentity">Imenujte %0%...</key>
+    <key alias="entername">Upišite ime...</key>
+    <key alias="enteremail">Upišite email...</key>
+    <key alias="enterusername">Upišite korisničko ime...</key>
+    <key alias="label">Oznaka...</key>
+    <key alias="enterDescription">Upišite opis...</key>
+    <key alias="search">Upišite za pretragu...</key>
+    <key alias="filter">Upišite za filtriranje...</key>
+    <key alias="enterTags">Upišite da dodate oznake (pritisnite enter nakon svake oznake)...</key>
+    <key alias="email">Upišite vaš email</key>
+    <key alias="enterMessage">Upišite poruku...</key>
+    <key alias="usernameHint">Vaše korisničko ime je obično vaš email</key>
+    <key alias="anchor">#value ili ?key=value</key>
+    <key alias="enterAlias">Upišite alias...</key>
+    <key alias="generatingAlias">Generiranje aliasa...</key>
+    <key alias="a11yCreateItem">Kreiraj stavku</key>
+    <key alias="a11yEdit">Uredi</key>
+    <key alias="a11yName">Naziv</key>
+  </area>
+  <area alias="editcontenttype">
+    <key alias="createListView" version="7.2">Kreirajte prilagođeni prikaz liste</key>
+    <key alias="removeListView" version="7.2">Ukloni prilagođeni prikaz liste</key>
+    <key alias="aliasAlreadyExists">Tip sadržaja, tip medija ili tip člana s ovim aliasom već postoji</key>
+  </area>
+  <area alias="renamecontainer">
+    <key alias="renamed">Preimenovano</key>
+    <key alias="enterNewFolderName">Upišite novi naziv mape</key>
+    <key alias="folderWasRenamed">%0% je preimenovan u %1%</key>
+  </area>
+  <area alias="editdatatype">
+    <key alias="addPrevalue">Dodajte vrijednost</key>
+    <key alias="dataBaseDatatype">Tip baze podataka</key>
+    <key alias="guid">Uređivač svojstva GUID</key>
+    <key alias="renderControl">Uređivač svojstva</key>
+    <key alias="rteButtons">Gumbi</key>
+    <key alias="rteEnableAdvancedSettings">Omogući napredne postavke za</key>
+    <key alias="rteEnableContextMenu">Omogući kontekstni meni</key>
+    <key alias="rteMaximumDefaultImgSize">Maksimalna zadana veličina umetnutih slika</key>
+    <key alias="rteRelatedStylesheets">Povezani stilovi</key>
+    <key alias="rteShowLabel">Prikaži oznaku</key>
+    <key alias="rteWidthAndHeight">Širina i visina</key>
+    <key alias="selectFolder">Odaberite mapu za premještanje</key>
+    <key alias="inTheTree">do u strukturi stabla ispod</key>
+    <key alias="wasMoved">je premeštena ispod</key>
+  </area>
+  <area alias="errorHandling">
+    <key alias="errorButDataWasSaved">Vaši podaci su spremljeni, ali prije nego što možete objaviti ovu stranicu postoje neke
+       greške koje prvo morate ispraviti:
+    </key>
+    <key alias="errorChangingProviderPassword">Trenutni provajder članstva ne podržava promjenu lozinke
+       (Omogući preuzimanje lozinke mora biti uključeno)
+    </key>
+    <key alias="errorExistsWithoutTab">%0% već postoji</key>
+    <key alias="errorHeader">Bilo je grešaka:</key>
+    <key alias="errorHeaderWithoutTab">Bilo je grešaka:</key>
+    <key alias="errorInPasswordFormat">Lozinka treba imati najmanje %0% znakova i sadržavati najmanje %1%
+      znakova koji nisu alfanumerički
+    </key>
+    <key alias="errorIntegerWithoutTab">%0% mora biti cijeli broj</key>
+    <key alias="errorMandatory">Polje %0% na kartici %1% je obavezno</key>
+    <key alias="errorMandatoryWithoutTab">%0% je obavezno polje</key>
+    <key alias="errorRegExp">%0% na %1% nije u ispravnom formatu</key>
+    <key alias="errorRegExpWithoutTab">%0% nije u ispravnom formatu</key>
+  </area>
+  <area alias="errors">
+    <key alias="receivedErrorFromServer">Primljena greška sa servera</key>
+    <key alias="dissallowedMediaType">Administrator je zabranio navedeni tip datoteke</key>
+    <key alias="codemirroriewarning">NAPOMENA! Iako je CodeMirror omogućen konfiguracijom, on je onemogućen u
+       Internet Explorer-u jer nije dovoljno stabilan.
+    </key>
+    <key alias="contentTypeAliasAndNameNotNull">Unesite i alias i ime na novu vrstu svojstva!</key>
+    <key alias="filePermissionsError">Postoji problem sa pristupom za čitanje/pisanje određenoj datoteci ili mapi</key>
+    <key alias="macroErrorLoadingPartialView">Greška pri učitavanju skripte parcijalnog prikaza (datoteka: %0%)</key>
+    <key alias="missingTitle">Unesite naslov</key>
+    <key alias="missingType">Molimo odaberite tip</key>
+    <key alias="pictureResizeBiggerThanOrg">Napravit ćete sliku veću od originalne veličine. Jeste li sigurni
+       da želite nastaviti?
+    </key>
+    <key alias="startNodeDoesNotExists">Početni čvor je obrisan, kontaktirajte svog administratora</key>
+    <key alias="stylesMustMarkBeforeSelect">Molimo označite sadržaj prije promjene stila</key>
+    <key alias="stylesNoStylesOnPage">Nema dostupnih aktivnih stilova</key>
+    <key alias="tableColMergeLeft">Postavite kursor lijevo od dvije ćelije koje želite spojiti</key>
+    <key alias="tableSplitNotSplittable">Ne možete podijeliti ćeliju koja nije spojena.</key>
+    <key alias="propertyHasErrors">Ovo svojstvo je nevažeće</key>
+  </area>
+  <area alias="general">
+    <key alias="about">O</key>
+    <key alias="action">Akcija</key>
+    <key alias="actions">Akcije</key>
+    <key alias="add">Dodaj</key>
+    <key alias="alias">Alias</key>
+    <key alias="all">Sve</key>
+    <key alias="areyousure">Jeste li sigurni?</key>
+    <key alias="back">Nazad</key>
+    <key alias="backToOverview">Nazad na pregled</key>
+    <key alias="border">Rub</key>
+    <key alias="by">od</key>
+    <key alias="cancel">Odustani</key>
+    <key alias="cellMargin">Margina ćelije</key>
+    <key alias="choose">Odaberi</key>
+    <key alias="clear">Očisti</key>
+    <key alias="close">Zatvori</key>
+    <key alias="closewindow">Zatvori prozor</key>
+    <key alias="closepane">Zatvori panel</key>
+    <key alias="comment">Komentar</key>
+    <key alias="confirm">Potvrdi</key>
+    <key alias="constrain">Ograniči</key>
+    <key alias="constrainProportions">Ograniči proporcije</key>
+    <key alias="content">Sadržaj</key>
+    <key alias="continue">Nastavi</key>
+    <key alias="copy">Kopiraj</key>
+    <key alias="create">Kreiraj</key>
+    <key alias="database">Baza podataka</key>
+    <key alias="date">Datum</key>
+    <key alias="default">Zadano</key>
+    <key alias="delete">Obriši</key>
+    <key alias="deleted">Obrisano</key>
+    <key alias="deleting">Brisanje...</key>
+    <key alias="design">Dizajn</key>
+    <key alias="dictionary">Riječnik</key>
+    <key alias="dimensions">Dimenzije</key>
+    <key alias="discard">Otkaži</key>
+    <key alias="down">Dolje</key>
+    <key alias="download">Preuzmi</key>
+    <key alias="edit">Uredi</key>
+    <key alias="edited">Uređeno</key>
+    <key alias="elements">Elementi</key>
+    <key alias="email">Email</key>
+    <key alias="error">Greška</key>
+    <key alias="field">Polje</key>
+    <key alias="findDocument">Pronađi</key>
+    <key alias="first">Prvi</key>
+    <key alias="focalPoint">Fokusna točka</key>
+    <key alias="general">Općenito</key>
+    <key alias="groups">Grupe</key>
+    <key alias="group">Grupa</key>
+    <key alias="height">Visina</key>
+    <key alias="help">Pomoć</key>
+    <key alias="hide">Sakrij</key>
+    <key alias="history">Povijest</key>
+    <key alias="icon">Ikona</key>
+    <key alias="id">Id</key>
+    <key alias="import">Uvezi</key>
+    <key alias="excludeFromSubFolders">Pretraži samo ovu mapu</key>
+    <key alias="info">Info</key>
+    <key alias="innerMargin">Unutrašnja margina</key>
+    <key alias="insert">Umetni</key>
+    <key alias="install">Instaliraj</key>
+    <key alias="invalid">Nevažeće</key>
+    <key alias="justify">Poravnaj</key>
+    <key alias="label">Oznaka</key>
+    <key alias="language">Jezik</key>
+    <key alias="last">Zadnji</key>
+    <key alias="layout">Izgled</key>
+    <key alias="links">Linkovi</key>
+    <key alias="loading">Učitavanje</key>
+    <key alias="locked">Zaključano</key>
+    <key alias="login">Prijava</key>
+    <key alias="logoff">Odjava</key>
+    <key alias="logout">Odjava</key>
+    <key alias="macro">Makro</key>
+    <key alias="mandatory">Obavezno</key>
+    <key alias="message">Poruka</key>
+    <key alias="move">Pomakni</key>
+    <key alias="name">Ime</key>
+    <key alias="new">Novo</key>
+    <key alias="next">Sljedeći</key>
+    <key alias="no">Ne</key>
+    <key alias="nodeName">Ime čvora</key>
+    <key alias="of">od</key>
+    <key alias="off">Isključeno</key>
+    <key alias="ok">OK</key>
+    <key alias="open">Otvori</key>
+    <key alias="options">Opcije</key>
+    <key alias="on">Uključeno</key>
+    <key alias="or">ili</key>
+    <key alias="orderBy">Poredaj po</key>
+    <key alias="password">Lozinka</key>
+    <key alias="path">Putanja</key>
+    <key alias="pleasewait">Trenutak molim...</key>
+    <key alias="previous">Prethodno</key>
+    <key alias="properties">Svojstva</key>
+    <key alias="readMore">Pročitaj više</key>
+    <key alias="rebuild">Ponovo izgradi</key>
+    <key alias="reciept">Email za primanje obrasca</key>
+    <key alias="recycleBin">Koš za smeće</key>
+    <key alias="recycleBinEmpty">Vaš koš za smeće je prazn</key>
+    <key alias="reload">Osvježi</key>
+    <key alias="remaining">Preostalo</key>
+    <key alias="remove">Izbriši</key>
+    <key alias="rename">Preimenuj</key>
+    <key alias="renew">Obnovi</key>
+    <key alias="required" version="7.0">Obavezno</key>
+    <key alias="retrieve">Povratiti</key>
+    <key alias="retry">Pokušaj ponovo</key>
+    <key alias="rights">Dozvole</key>
+    <key alias="scheduledPublishing">Planirano objavljivanje</key>
+    <key alias="umbracoInfo">Umbraco info</key>
+    <key alias="search">Traži</key>
+    <key alias="searchNoResult">Žao nam je, ne možemo pronaći ono što tražite.</key>
+    <key alias="noItemsInList">Nije dodana nijedna stavka</key>
+    <key alias="server">Server</key>
+    <key alias="settings">Postavke</key>
+    <key alias="show">Prikaži</key>
+    <key alias="showPageOnSend">Prikaži stranicu nprilikom Slanja</key>
+    <key alias="size">Veličina</key>
+    <key alias="sort">Sortiranje</key>
+    <key alias="status">Status</key>
+    <key alias="submit">Potvrdi</key>
+    <key alias="success">Uspjeh</key>
+    <key alias="type">Tip</key>
+    <key alias="typeName">Ime tipa</key>
+    <key alias="typeToSearch">Upišite za pretragu...</key>
+    <key alias="under">ispod</key>
+    <key alias="up">Gore</key>
+    <key alias="update">Ažuriraj</key>
+    <key alias="upgrade">Nadogradi</key>
+    <key alias="upload">Prenesi</key>
+    <key alias="url">URL</key>
+    <key alias="user">Korisnik</key>
+    <key alias="username">Korisničko ime</key>
+    <key alias="value">Vrijednost</key>
+    <key alias="view">Pogled</key>
+    <key alias="welcome">Dobrodošli...</key>
+    <key alias="width">Širina</key>
+    <key alias="yes">Da</key>
+    <key alias="folder">Mapa</key>
+    <key alias="searchResults">Rezultati pretrage</key>
+    <key alias="reorder">Promijeni redosljed</key>
+    <key alias="reorderDone">Završeno sortiranje</key>
+    <key alias="preview">Pregled</key>
+    <key alias="changePassword">Promijeni lozinku</key>
+    <key alias="to">do</key>
+    <key alias="listView">Prikaz liste</key>
+    <key alias="saving">Spremanje...</key>
+    <key alias="current">trenutni</key>
+    <key alias="embed">Ugradi</key>
+    <key alias="selected">odabran</key>
+    <key alias="other">Ostalo</key>
+    <key alias="articles">Članci</key>
+    <key alias="videos">Videi</key>
+    <key alias="avatar">Avatar za</key>
+    <key alias="header">Zaglavlje</key>
+    <key alias="systemField">sistemsko polje</key>
+    <key alias="lastUpdated">Posljednje ažurirano</key>
+  </area>
+  <area alias="colors">
+    <key alias="blue">Plava</key>
+  </area>
+  <area alias="shortcuts">
+    <key alias="addGroup">Dodaj grupu</key>
+    <key alias="addProperty">Dodaj svojstvo</key>
+    <key alias="addEditor">Dodaj urednika</key>
+    <key alias="addTemplate">Dodaj predložak</key>
+    <key alias="addChildNode">Dodajte podređeni čvor</key>
+    <key alias="addChild">Dodaj dijete</key>
+    <key alias="editDataType">Uredite tip podataka</key>
+    <key alias="navigateSections">Krećite se po odjeljcima</key>
+    <key alias="shortcut">Prečice</key>
+    <key alias="showShortcuts">Prikaži prečice</key>
+    <key alias="toggleListView">Uključi prikaz liste</key>
+    <key alias="toggleAllowAsRoot">Uključi dozvoli kao root</key>
+    <key alias="commentLine">Redovi za komentiranje/dekomentiranje</key>
+    <key alias="removeLine">Uklonite liniju</key>
+    <key alias="copyLineUp">Kopiraj linije gore</key>
+    <key alias="copyLineDown">Kopiraj linije dole</key>
+    <key alias="moveLineUp">Pomakni linije gore</key>
+    <key alias="moveLineDown">Pomakni linije dole</key>
+    <key alias="generalHeader">Općenito</key>
+    <key alias="editorHeader">Uređivač</key>
+    <key alias="toggleAllowCultureVariants">Uključi dozvoli varijante kulture</key>
+  </area>
+  <area alias="graphicheadline">
+    <key alias="backgroundcolor">Boja pozadine</key>
+    <key alias="bold">Podebljano</key>
+    <key alias="color">Boja teksta</key>
+    <key alias="font">Font</key>
+    <key alias="text">Tekst</key>
+  </area>
+  <area alias="headers">
+    <key alias="page">Stranica</key>
+  </area>
+  <area alias="installer">
+    <key alias="databaseErrorCannotConnect">Instalacija se ne može povezati s bazom podataka.</key>
+    <key alias="databaseErrorWebConfig">Nije moguće spremiti web.config datoteku. Molimo izmijenite konekcijski string
+       ručno.
+    </key>
+    <key alias="databaseFound">Vaša baza podataka je pronađena i identificirana je kao</key>
+    <key alias="databaseHeader">Konfiguracija baze podataka</key>
+    <key alias="databaseInstall">
+      <![CDATA[
+      Pritisnite <strong>Instaliraj</strong> za instalaciju Umbraco %0% baze podataka
+    ]]>
+    </key>
+    <key alias="databaseInstallDone">
+      <![CDATA[Umbraco %0% je sada kopiran u vašu bazu podataka. Pritisnite <strong>Dalje</strong> da nastavite.]]></key>
+    <key alias="databaseNotFound"><![CDATA[<p>Baza podataka nije pronađena! Provjerite jesu li informacije u "konekcijskom string" u "web.config" datoteci ispravne.</p>
+              <p>Da nastavite, uredite "web.config" datoteku. (koristeći Visual Studio ili vaš omiljeni uređivač teksta), skorlajte do dna, dodajte konekcijski string za vašu bazu podataka u svojstvo nazvan "UmbracoDbDSN" i spremite datoteku. </p>
+              <p>
+              Kliknite na gumb <strong>pokušaj ponovo</strong> kada završite.<br />
+			  <a href="https://our.umbraco.com/documentation/Reference/Config/webconfig/" target="_blank" rel="noopener">
+			              Više informacija o uređivanju web.config datoteke možete pronaći ovdje</a>.</p>]]></key>
+    <key alias="databaseText"><![CDATA[Da bi dovršili ovaj korak, morate znati neke informacije o vašem poslužitelju baze podataka ("konekcijski string").<br />
+        Molimo kontaktirajte svog ISP-a ako je potrebno.
+        Ako instalirate na lokalnoj mašini ili serveru, možda će vam trebati informacije od administratora sistema.]]></key>
+    <key alias="databaseUpgrade"><![CDATA[
+      <p>
+      Pritisnite <strong>nadogradnja</strong> za nadogradnju vaše baze podataka na Umbraco %0%</p>
+      <p>
+      Ne brinite - nijedan sadržaj neće biti obrisan i sve će nastaviti raditi nakon toga!
+      </p>
+      ]]>    </key>
+    <key alias="databaseUpgradeDone"><![CDATA[Vaša baza podataka je nadograđena na novu verziju %0%.<br />Pritisnite <strong>Dalje</strong> da nastavite.]]></key>
+    <key alias="databaseUpToDate">
+      <![CDATA[Vaša trenutna baza podataka je ažurirana!. Pritisnite <strong>Dalje</strong> da nastavite sa čarobnjakom za konfiguraciju]]></key>
+    <key alias="defaultUserChangePass">
+      <![CDATA[<strong>Zadanu korisničku lozinku treba promijeniti!</strong>]]></key>
+    <key alias="defaultUserDisabled">
+      <![CDATA[<strong>Zadani korisnik je onemogućen ili nema pristup Umbraco-u!</strong></p><p>Ne treba preduzimati nikakve daljnje radnje. Pritisnite <strong>Dalje</strong> da nastavite.]]></key>
+    <key alias="defaultUserPassChanged">
+      <![CDATA[<strong>Zadana korisnička lozinka je uspješno promijenjena od instalacije!</strong></p><p>Ne treba preduzimati nikakve daljnje radnje. Pritisnite <strong>Dalje</strong> da nastavite.]]></key>
+    <key alias="defaultUserPasswordChanged">Lozinka je promijenjena!</key>
+    <key alias="greatStart">Započnite odlično, pogledajte naše uvodne video zapise</key>
+    <key alias="licenseText">Klikom na sljedeći gumb (ili modifikacijom umbracoConfigurationStatus u web.config),
+       prihvaćate licencu za ovaj softver kao što je navedeno u polju ispod. Primijetite da se ova Umbraco distribucija
+       sastoji se od dvije različite licence, open source MIT licence za okvir i licence za besplatni softver Umbraco
+       koji pokriva korisničko sučelje.
+    </key>
+    <key alias="None">Još nije instalirano.</key>
+    <key alias="permissionsAffectedFolders">Zahvaćene datoteke i mape</key>
+    <key alias="permissionsAffectedFoldersMoreInfo">Više informacija o postavljanju dozvola za Umbraco ovdje</key>
+    <key alias="permissionsAffectedFoldersText">Morate dodijeliti dozvole za izmjenu ASP.NET-a za sljedeće
+       datoteke/mape
+    </key>
+    <key alias="permissionsAlmostPerfect"><![CDATA[<strong>Vaše postavke dozvola su gotovo savršene!</strong><br /><br />
+        Možete pokrenuti Umbraco bez problema, ali nećete moći instalirati pakete koji se preporučuju da biste u potpunosti iskoristili Umbraco.]]></key>
+    <key alias="permissionsHowtoResolve">Kako riješiti</key>
+    <key alias="permissionsHowtoResolveLink">Kliknite ovdje da pročitate tekstualnu verziju</key>
+    <key alias="permissionsHowtoResolveText">
+      <![CDATA[Gledajte naše <strong>video tutorijale</strong> o postavljanju dozvola foldera za Umbraco ili pročitajte tekstualnu verziju.]]></key>
+    <key alias="permissionsMaybeAnIssue"><![CDATA[<strong>Vaše postavke dozvola mogu biti problem!</strong>
+      <br/><br />
+      Možete pokrenuti Umbraco bez problema, ali nećete moći kreirati mape ili instalirati pakete koji se preporučuju da biste u potpunosti iskoristili Umbraco.]]></key>
+    <key alias="permissionsNotReady"><![CDATA[<strong>Vaše postavke dozvola nisu spremne za Umbraco!</strong>
+          <br /><br />
+          Da biste pokrenuli Umbraco, morat ćete ažurirati postavke dozvola.]]></key>
+    <key alias="permissionsPerfect"><![CDATA[<strong>Vaše postavke dozvola su savršene!</strong><br /><br />
+              Spremni ste da pokrenete Umbraco i instalirate pakete!]]></key>
+    <key alias="permissionsResolveFolderIssues">Rješavanje problema sa mapom</key>
+    <key alias="permissionsResolveFolderIssuesLink">Pratite ovu vezu za više informacija o problemima sa ASP.NET i
+       kreiranje mapa
+    </key>
+    <key alias="permissionsSettingUpPermissions">Postavljanje dozvola za mape</key>
+    <key alias="permissionsText"><![CDATA[
+      Umbraco treba pristup za pisanje/izmjenu određenih mapa kako bi pohranio datoteke poput slika i PDF-ova.
+      Također pohranjuje privremene podatke (tj: cache) za poboljšanje performansi vaše web stranice.
+    ]]>    </key>
+    <key alias="runwayFromScratch">Želim početi od nule</key>
+    <key alias="runwayFromScratchText"><![CDATA[
+        Vaša web stranica je trenutno potpuno prazna, tako da je savršeno ako želite početi od nule i kreirati vlastite vrste dokumenata i predloške.
+        (<a href="https://umbraco.tv/documentation/videos/for-site-builders/foundation/document-types">naučite kako</a>)
+        I dalje možete odabrati da kasnije instalirate Runway. Molimo idite na odjeljak Developer i odaberite Paketi.
+      ]]>    </key>
+    <key alias="runwayHeader">Upravo ste postavili čistu Umbraco platformu. Šta želite sljedeće učiniti?</key>
+    <key alias="runwayInstalled">Runway je instaliran</key>
+    <key alias="runwayInstalledText"><![CDATA[
+      Imate postavljene temelje. Odaberite koje module želite instalirati na njega.<br />
+      Ovo je naša lista preporučenih modula, označite one koje želite da instalirate ili pogledajte <a href="#" onclick="toggleModules(); return false;" id="toggleModuleList">punu listu modula</a>
+      ]]>    </key>
+    <key alias="runwayOnlyProUsers">Preporučuje se samo iskusnim korisnicima</key>
+    <key alias="runwaySimpleSite">Želim početi s jednostavnom web-stranicom</key>
+    <key alias="runwaySimpleSiteText"><![CDATA[
+      <p>
+      "Runway" je jednostavna web stranica koja nudi neke osnovne tipove dokumenata i predloške. Instalacijski čarobnjak može postaviti Runway za vas automatski,
+        ali ga možete lako urediti, proširiti ili ukloniti. Nije potrebno i možete savršeno koristiti Umbraco i bez njega. Kako god,
+        Runway nudi laku osnovu zasnovanu na najboljim praksama za početak brže nego ikad.
+        Ako se odlučite za instalaciju Runway, opcionalo možete odabrati osnovne građevne blokove tzv. Runway Modules da poboljšate svoje Runway stranice.
+        </p>
+        <small>
+        <em>Uključeno u Runway:</em> Početna stranica, Stranica za početak, Stranica za instaliranje modula.<br />
+        <em>Dodatni moduli:</em> Navigacija, Sitemap, Kontakt, Galerija.
+        </small>
+      ]]>    </key>
+    <key alias="runwayWhatIsRunway">Što je Runway</key>
+    <key alias="step1">Korak 1/5: Prihvatite licencu</key>
+    <key alias="step2">Korak 2/5: Konfiguracija baze podataka</key>
+    <key alias="step3">Korak 3/5: Potvrđivanje dozvola za datoteke</key>
+    <key alias="step4">Korak 4/5: Provjerite Umbraco sigurnost</key>
+    <key alias="step5">Korak 5/5: Umbraco je spreman za početak</key>
+    <key alias="thankYou">Hvala vam što ste odabrali Umbraco</key>
+    <key alias="theEndBrowseSite"><![CDATA[<h3>Pregledajte svoju novu stranicu</h3>
+Instalirali ste Runway, pa zašto ne biste vidjeli kako izgleda vaša nova web stranica.]]></key>
+    <key alias="theEndFurtherHelp"><![CDATA[<h3>Dodatna pomoć i informacije</h3>
+Potražite pomoć od naše nagrađivane zajednice, pregledajte dokumentaciju ili pogledajte nekoliko besplatnih videozapisa o tome kako napraviti jednostavnu stranicu, kako koristiti pakete i brzi vodič za terminologiju Umbraco]]></key>
+    <key alias="theEndHeader">Umbraco %0% je instaliran i spreman za upotrebu</key>
+    <key alias="theEndInstallFailed"><![CDATA[Da biste završili instalaciju, morat ćete
+        ručno urediti <strong>/web.config datoteku</strong> i ažurirati svojstvo unutar AppSetting <strong>UmbracoConfigurationStatus</strong> na dnu do vrijednosti od <strong>'%0%'</strong>.]]></key>
+    <key alias="theEndInstallSuccess"><![CDATA[Možete dobiti <strong>započeti odmah</strong> klikom na "Pokreni Umbraco" gumb ispod. <br />Ako ste <strong>novi u Umbraco-u</strong>,
+možete pronaći mnogo resursa na našim stranicama za početak.]]></key>
+    <key alias="theEndOpenUmbraco"><![CDATA[<h3>Pokreni Umbraco</h3>
+Da bi upravljali svojom web lokacijom, jednostavno otvorite Umbraco backoffice i počnite dodavati sadržaj, ažurirati predloške i stilove ili dodati novu funkcionalnost]]></key>
+    <key alias="Unavailable">Povezivanje s bazom podataka nije uspjelo.</key>
+    <key alias="Version3">Umbraco Verzija 3</key>
+    <key alias="Version4">Umbraco Verzija 4</key>
+    <key alias="watch">Gledaj</key>
+    <key alias="welcomeIntro"><![CDATA[Ovaj čarobnjak će vas voditi kroz proces konfiguracije <strong>Umbraco %0%</strong> za novu instalaciju ili nadogradnju sa verzije 3.0.
+                                <br /><br />
+                                Pritisnite <strong>"Dalje"</strong> da pokrenete čarobnjaka.]]></key>
+  </area>
+  <area alias="language">
+    <key alias="cultureCode">Kod kulture</key>
+    <key alias="displayName">Naziv kulture</key>
+  </area>
+  <area alias="lockout">
+    <key alias="lockoutWillOccur">Bili ste u stanju mirovanja i automatski će doći do odjave</key>
+    <key alias="renewSession">Obnovite sada da sačuvate svoj rad</key>
+  </area>
+  <area alias="login">
+    <key alias="greeting0">Sretna super nedelja</key>
+    <key alias="greeting1">Sretan divan ponedeljak</key>
+    <key alias="greeting2">Sretan specifičan utorak</key>
+    <key alias="greeting3">Sretna divna srijeda</key>
+    <key alias="greeting4">Sretan gromoglasan četvrtak</key>
+    <key alias="greeting5">Sretan zanimljiv petak</key>
+    <key alias="greeting6">Sretna opuštena subota</key>
+    <key alias="instruction">Prijavite se u nastavku</key>
+    <key alias="signInWith">Prijav sa</key>
+    <key alias="timeout">Isteklo je vrijeme sesije</key>
+    <key alias="bottomText">
+      <![CDATA[<p style="text-align:right;">&copy; 2001 - %0% <br /><a href="https://umbraco.com" style="text-decoration: none" target="_blank" rel="noopener">Umbraco.com</a></p> ]]></key>
+    <key alias="forgottenPassword">Zaboravljena lozinka?</key>
+    <key alias="forgottenPasswordInstruction">E-mail poruka bit će poslana na navedenu adresu sa linkom za resetiranje lozinke</key>
+    <key alias="requestPasswordResetConfirmation">E-mail poruka s uputama za poništavanje lozinke će biti poslana na navedenu adresu ukoliko odgovara našoj evidenciji</key>
+    <key alias="showPassword">Prikaži lozinku</key>
+    <key alias="hidePassword">Sakrij lozinku</key>
+    <key alias="returnToLogin">Povratak na obrazac za prijavu</key>
+    <key alias="setPasswordInstruction">Molimo unesite novu lozinku</key>
+    <key alias="setPasswordConfirmation">Vaša lozinka je ažurirana</key>
+    <key alias="resetCodeExpired">Link na koji ste kliknuli je nevažeći ili je istekao</key>
+    <key alias="resetPasswordEmailCopySubject">Umbraco: Reset lozinke</key>
+    <key alias="resetPasswordEmailCopyFormat"><![CDATA[
+        <html>
+			<head>
+				<meta name='viewport' content='width=device-width'>
+				<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
+			</head>
+			<body class='' style='font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; color: #392F54; line-height: 22px; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background: #1d1333; margin: 0; padding: 0;' bgcolor='#1d1333'>
+				<style type='text/css'> @media only screen and (max-width: 620px) {table[class=body] h1 {font-size: 28px !important; margin-bottom: 10px !important; } table[class=body] .wrapper {padding: 32px !important; } table[class=body] .article {padding: 32px !important; } table[class=body] .content {padding: 24px !important; } table[class=body] .container {padding: 0 !important; width: 100% !important; } table[class=body] .main {border-left-width: 0 !important; border-radius: 0 !important; border-right-width: 0 !important; } table[class=body] .btn table {width: 100% !important; } table[class=body] .btn a {width: 100% !important; } table[class=body] .img-responsive {height: auto !important; max-width: 100% !important; width: auto !important; } } .btn-primary table td:hover {background-color: #34495e !important; } .btn-primary a:hover {background-color: #34495e !important; border-color: #34495e !important; } .btn  a:visited {color:#FFFFFF;} </style>
+				<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;" bgcolor="#1d1333">
+					<tr>
+						<td style="font-family: sans-serif; font-size: 14px; vertical-align: top; padding: 24px;" valign="top">
+							<table style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+								<tr>
+									<td background="https://umbraco.com/umbraco/assets/img/application/logo.png" bgcolor="#1d1333" width="28" height="28" valign="top" style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+										<!--[if gte mso 9]> <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:30px;height:30px;"> <v:fill type="tile" src="https://umbraco.com/umbraco/assets/img/application/logo.png" color="#1d1333" /> <v:textbox inset="0,0,0,0"> <![endif]-->
+<div></div>
+<!--[if gte mso 9]> </v:textbox> </v:rect> <![endif]-->
+</td>
+<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top"></td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+<table border='0' cellpadding='0' cellspacing='0' class='body' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;' bgcolor='#1d1333'>
+<tr>
+<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'></td>
+<td class='container' style='font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; max-width: 560px; width: 560px; margin: 0 auto; padding: 10px;' valign='top'>
+<div class='content' style='box-sizing: border-box; display: block; max-width: 560px; margin: 0 auto; padding: 10px;'>
+<br>
+<table class='main' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; border-radius: 3px; background: #FFFFFF;' bgcolor='#FFFFFF'>
+<tr>
+<td class='wrapper' style='font-family: sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 50px;' valign='top'>
+<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;'>
+<tr>
+<td style='line-height: 24px; font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'>
+<h1 style='color: #392F54; font-family: sans-serif; font-weight: bold; line-height: 1.4; font-size: 24px; text-align: left; text-transform: capitalize; margin: 0 0 30px;' align='left'>
+															Zatraženo je ponovno postavljanje lozinke
+														</h1>
+<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+															Vaše korisničko ime za prijavu na Umbraco backoffice je: <strong>%0%</strong>
+</p>
+<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;'>
+<tbody>
+<tr>
+<td style='font-family: sans-serif; font-size: 14px; vertical-align: top; border-radius: 5px; text-align: center; background: #35C786;' align='center' bgcolor='#35C786' valign='top'>
+<a href='%1%' target='_blank' rel='noopener' style='color: #FFFFFF; text-decoration: none; -ms-word-break: break-all; word-break: break-all; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; text-transform: capitalize; background: #35C786; margin: 0; padding: 12px 30px; border: 1px solid #35c786;'>
+																				Kliknite na ovaj link da poništite lozinku
+																			</a>
+</td>
+</tr>
+</tbody>
+</table>
+</p>
+<p style='max-width: 400px; display: block; color: #392F54; font-family: sans-serif; font-size: 14px; line-height: 20px; font-weight: normal; margin: 15px 0;'>Ukoliko ne možete kliknuti na link, kopirajte i zalijepite ovaj URL u prozor vašeg pretraživača:</p>
+<table border='0' cellpadding='0' cellspacing='0'>
+<tr>
+<td style='-ms-word-break: break-all; word-break: break-all; font-family: sans-serif; font-size: 11px; line-height:14px;'>
+<font style="-ms-word-break: break-all; word-break: break-all; font-size: 11px; line-height:14px;">
+<a style='-ms-word-break: break-all; word-break: break-all; color: #392F54; text-decoration: underline; font-size: 11px; line-height:15px;' href='%1%'>%1%</a>
+</font>
+</td>
+</tr>
+</table>
+</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+<br><br><br>
+</div>
+</td>
+<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'></td>
+</tr>
+</table>
+</body>
+</html>
+	]]>    </key>
+    <key alias="mfaSecurityCodeSubject">Umbraco: Sigurnosni kod</key>
+    <key alias="mfaSecurityCodeMessage">Vaš sigurnosni kod je: %0%</key>
+    <key alias="2faTitle">Posljednji korak</key>
+    <key alias="2faText">Omogućili ste 2-faktorsku autentifikaciju i morate potvrditi svoj identitet.</key>
+    <key alias="2faMultipleText">Molimo odaberite 2-faktor provajdera</key>
+    <key alias="2faCodeInput">Verifikacijski kod</key>
+    <key alias="2faCodeInputHelp">Unesite verifikacijski kod</key>
+    <key alias="2faInvalidCode">Unesen je nevažeći kod</key>
+  </area>
+  <area alias="main">
+    <key alias="dashboard">Kontrolna ploča</key>
+    <key alias="sections">Sekcije</key>
+    <key alias="tree">Sadržaj</key>
+  </area>
+  <area alias="moveOrCopy">
+    <key alias="choose">Odaberite stranicu iznad...</key>
+    <key alias="copyDone">%0% je kopiran u %1%</key>
+    <key alias="copyTo">Odaberite gdje dokument %0% treba kopirati ispod</key>
+    <key alias="moveDone">%0% je premješten u %1%</key>
+    <key alias="moveTo">Odaberite gdje dokument %0% treba premjestiti ispod</key>
+    <key alias="nodeSelected">je odabrano kao korijen vašeg novog sadržaja, kliknite na 'Uredu' ispod.</key>
+    <key alias="noNodeSelected">Još nije odabran čvor, molimo odaberite čvor na gornjoj listi prije nego kliknete na 'Uredu'</key>
+    <key alias="notAllowedByContentType">Trenutni čvor nije dozvoljen pod odabranim čvorom zbog njegovog tipa</key>
+    <key alias="notAllowedByPath">Trenutni čvor se ne može premjestiti na jednu od njegovih podstranica niti roditelj i odredište mogu biti isti</key>
+    <key alias="notAllowedAtRoot">Trenutni čvor ne može postojati u korijenu</key>
+    <key alias="notValid">Radnja nije dozvoljena jer nemate dovoljna dopuštenja za 1 ili više djece
+       dokumenata.
+    </key>
+    <key alias="relateToOriginal">Povežite kopirane stavke s originalom</key>
+  </area>
+  <area alias="notifications">
+    <key alias="editNotifications"><![CDATA[Odaberite vaše obavijesti za <strong>%0%</strong>]]></key>
+    <key alias="notificationsSavedFor">Postavke obavijesti su spremljene za</key>
+    <key alias="mailBody"><![CDATA[
+      Zdravo %0%
+
+      Ovo je automatizirana poruka koja vas obavještava da je zadatak '%1%'
+      izvršen na stranici '%2%'
+      od korisnika '%3%'
+
+      Idite na http://%4%/#/content/content/edit/%5% za uređivanje.
+
+      %6%
+
+      Ugodan dan!
+      Pozdrav od Umbraco robota
+    ]]>    </key>
+    <key alias="mailBodyVariantSummary">Sljedeći jezici su izmijenjeni %0%</key>
+    <key alias="mailBodyHtml"><![CDATA[
+        <html>
+			<head>
+				<meta name='viewport' content='width=device-width'>
+				<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
+			</head>
+			<body class='' style='font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; color: #392F54; line-height: 22px; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background: #1d1333; margin: 0; padding: 0;' bgcolor='#1d1333'>
+				<style type='text/css'> @media only screen and (max-width: 620px) {table[class=body] h1 {font-size: 28px !important; margin-bottom: 10px !important; } table[class=body] .wrapper {padding: 32px !important; } table[class=body] .article {padding: 32px !important; } table[class=body] .content {padding: 24px !important; } table[class=body] .container {padding: 0 !important; width: 100% !important; } table[class=body] .main {border-left-width: 0 !important; border-radius: 0 !important; border-right-width: 0 !important; } table[class=body] .btn table {width: 100% !important; } table[class=body] .btn a {width: 100% !important; } table[class=body] .img-responsive {height: auto !important; max-width: 100% !important; width: auto !important; } } .btn-primary table td:hover {background-color: #34495e !important; } .btn-primary a:hover {background-color: #34495e !important; border-color: #34495e !important; } .btn  a:visited {color:#FFFFFF;} </style>
+				<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;" bgcolor="#1d1333">
+					<tr>
+						<td style="font-family: sans-serif; font-size: 14px; vertical-align: top; padding: 24px;" valign="top">
+							<table style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+								<tr>
+									<td background="https://umbraco.com/umbraco/assets/img/application/logo.png" bgcolor="#1d1333" width="28" height="28" valign="top" style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+										<!--[if gte mso 9]> <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:30px;height:30px;"> <v:fill type="tile" src="https://umbraco.com/umbraco/assets/img/application/logo.png" color="#1d1333" /> <v:textbox inset="0,0,0,0"> <![endif]-->
+<div></div>
+<!--[if gte mso 9]> </v:textbox> </v:rect> <![endif]-->
+</td>
+<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top"></td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+<table border='0' cellpadding='0' cellspacing='0' class='body' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;' bgcolor='#1d1333'>
+<tr>
+<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'></td>
+<td class='container' style='font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; max-width: 560px; width: 560px; margin: 0 auto; padding: 10px;' valign='top'>
+<div class='content' style='box-sizing: border-box; display: block; max-width: 560px; margin: 0 auto; padding: 10px;'>
+<br>
+<table class='main' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; border-radius: 3px; background: #FFFFFF;' bgcolor='#FFFFFF'>
+<tr>
+<td class='wrapper' style='font-family: sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 50px;' valign='top'>
+<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;'>
+<tr>
+<td style='line-height: 24px; font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'>
+<h1 style='color: #392F54; font-family: sans-serif; font-weight: bold; line-height: 1.4; font-size: 24px; text-align: left; text-transform: capitalize; margin: 0 0 30px;' align='left'>
+															Pozdrav %0%,
+														</h1>
+<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+															Ovo je automatiziran email koja vas obavještava da je zadatak <strong>'%1%'</strong> izvršen na stranici <a style="color: #392F54; text-decoration: none; -ms-word-break: break-all; word-break: break-all;" href="http://%4%/#/content/content/edit/%5%"><strong>'%2%'</strong></a> od korisnika <strong>'%3%'</strong>
+</p>
+<table border='0' cellpadding='0' cellspacing='0' class='btn btn-primary' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;'>
+<tbody>
+<tr>
+<td align='left' style='font-family: sans-serif; font-size: 14px; vertical-align: top; padding-bottom: 15px;' valign='top'>
+<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;'><tbody><tr>
+<td style='font-family: sans-serif; font-size: 14px; vertical-align: top; border-radius: 5px; text-align: center; background: #35C786;' align='center' bgcolor='#35C786' valign='top'>
+<a href='http://%4%/#/content/content/edit/%5%' target='_blank' rel='noopener' style='color: #FFFFFF; text-decoration: none; -ms-word-break: break-all; word-break: break-all; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; text-transform: capitalize; background: #35C786; margin: 0; padding: 12px 30px; border: 1px solid #35c786;'>EDIT</a></td></tr></tbody></table>
+</td>
+</tr>
+</tbody>
+</table>
+<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+<h3>Sažetak izmjena:</h3>
+															%6%
+														</p>
+<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+															Ugodan dan!<br /><br />
+															Pozdrav od Umbraco robota
+														</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+<br><br><br>
+</div>
+</td>
+<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'></td>
+</tr>
+</table>
+</body>
+</html>
+	]]>    </key>
+    <key alias="mailBodyVariantHtmlSummary"><![CDATA[<p>Sljedeći jezici su izmijenjeni:</p>
+        %0%
+    ]]>    </key>
+    <key alias="mailSubject">[%0%] Obavijesti o %1% izvedena na %2%</key>
+    <key alias="notifications">Obavijesti</key>
+  </area>
+  <area alias="packager">
+    <key alias="actions">Akcije</key>
+    <key alias="created">Kreirano</key>
+    <key alias="createPackage">Kreiraj paket</key>
+    <key alias="chooseLocalPackageText"><![CDATA[
+      Odaberite paket sa vašeg računala klikom na Pregledaj<br />
+         i odaberite paket. Umbraco paketi uglavnom imaju ".umb" ili ".zip" ekstenziju.
+      ]]>    </key>
+    <key alias="deletewarning">Ovo će obrisati paket</key>
+    <key alias="includeAllChildNodes">Uključi sve podređene čvorove</key>
+    <key alias="installed">Instalirano</key>
+    <key alias="installedPackages">Instalirani paketi</key>
+    <key alias="installInstructions">Uputstva za instalaciju</key>
+    <key alias="noConfigurationView">Ovaj paket nema prikaz konfiguracije</key>
+    <key alias="noPackagesCreated">Još nije kreiran nijedan paket</key>
+    <key alias="noPackages">Nijedan paket nije instaliran</key>
+    <key alias="noPackagesDescription">
+      <![CDATA[Pregledajte dostupne pakete koristeći ikonu <strong>'Paketi'</strong> u gornjem desnom uglu ekrana]]></key>
+    <key alias="packageContent">Sadržaj paketa</key>
+    <key alias="packageLicense">Licenca</key>
+    <key alias="packageSearch">Pretražite pakete</key>
+    <key alias="packageSearchResults">Rezultati za</key>
+    <key alias="packageNoResults">Nismo mogli pronaći ništa za</key>
+    <key alias="packageNoResultsDescription">Pokušajte potražiti drugi paket ili pregledajte kategorije
+    </key>
+    <key alias="packagesPopular">Popularno</key>
+    <key alias="packagesPromoted">Promocije</key>
+    <key alias="packagesNew">Nova izdanja</key>
+    <key alias="packageHas">ima</key>
+    <key alias="packageKarmaPoints">karma bodovi</key>
+    <key alias="packageInfo">Informacije</key>
+    <key alias="packageOwner">Vlasnik</key>
+    <key alias="packageContrib">Suradnici</key>
+    <key alias="packageCreated">Kreirano</key>
+    <key alias="packageCurrentVersion">Trenutna verzija</key>
+    <key alias="packageNetVersion">.NET verzija</key>
+    <key alias="packageDownloads">Preuzimanja</key>
+    <key alias="packageLikes">Lajkovi</key>
+    <key alias="packageCompatibility">Kompatibilnost</key>
+    <key alias="packageCompatibilityDescription">Ovaj paket je kompatibilan sa sljedećim verzijama Umbraco-a, kako su
+      prijavili članovi zajednice. Potpuna kompatibilnost se ne može garantirati za dolje navedene verzije 100%
+    </key>
+    <key alias="packageExternalSources">Vanjske poveznice</key>
+    <key alias="packageAuthor">Autor</key>
+    <key alias="packageDocumentation">Dokumentacija</key>
+    <key alias="packageMetaData">Meta podaci paketa</key>
+    <key alias="packageName">Naziv paketa</key>
+    <key alias="packageNoItemsHeader">Paket ne sadrži nikakve stavke</key>
+    <key alias="packageNoItemsText"><![CDATA[Ovaj paket ne sadrži nijednu stavku za deinstalaciju.<br/><br/>
+      Ovo možete bezbjedno ukloniti iz sistema klikom na "deinstaliraj paket".]]></key>
+    <key alias="packageOptions">Opcije paketa</key>
+    <key alias="packageMigrationsRun">Pokrenite migracije paketa na čekanju</key>
+    <key alias="packageReadme">Readme paketa</key>
+    <key alias="packageRepository">Repozitorij paketa</key>
+    <key alias="packageUninstallConfirm">Potvrdi deinstalaciju paketa</key>
+    <key alias="packageUninstalledHeader">Paket je deinstaliran</key>
+    <key alias="packageUninstalledText">Paket je uspješno deinstaliran</key>
+    <key alias="packageUninstallHeader">Deinstaliraj paket</key>
+    <key alias="packageUninstallText"><![CDATA[U nastavku možete poništiti odabir stavki koje trenutno ne želite ukloniti. Kada kliknete na "potvrdi deinstalaciju" sve označene stavke će biti uklonjene.<br />
+      <span style="color: Red; font-weight: bold;">Bilješka:</span> svi dokumenti, mediji itd. u zavisnosti od stavki koje uklonite, prestat će raditi i mogu dovesti do nestabilnosti sistema,
+      pa deinstalirajte sa oprezom. Ako ste u nedoumici, kontaktirajte autora paketa.]]></key>
+    <key alias="packageVersion">Verzija paketa</key>
+    <key alias="verifiedToWorkOnUmbracoCloud">Provjereno za rad na Umbraco Cloud</key>
+  </area>
+  <area alias="paste">
+    <key alias="doNothing">Zalijepi s punim formatiranjem (nije preporučljivo)</key>
+    <key alias="errorMessage">Tekst koji pokušavate zalijepiti sadrži posebne znakove ili formatiranje. Ovo bi moglo biti
+       uzrokovano kopiranjem teksta iz programa Microsoft Word. Umbraco može automatski ukloniti posebne znakove ili formatiranje, tako da
+       zalijepljeni sadržaj će biti prikladniji za web.
+    </key>
+    <key alias="removeAll">Zalijepite kao običan tekst bez ikakvog oblikovanja</key>
+    <key alias="removeSpecialFormattering">Zalijepi, ali ukloni oblikovanje (preporučeno)</key>
+  </area>
+  <area alias="publicAccess">
+    <key alias="paGroups">Grupna zaštita</key>
+    <key alias="paGroupsHelp">Ako želite dodijeliti pristup svim članovima određenih grupa članova</key>
+    <key alias="paGroupsNoGroups">Morate kreirati grupu članova prije nego što možete koristiti grupnu autentifikaciju</key>
+    <key alias="paErrorPage">Stranica sa greškom</key>
+    <key alias="paErrorPageHelp">Koristi se kada su ljudi prijavljeni, ali nemaju pristup</key>
+    <key alias="paHowWould"><![CDATA[Odaberite kako ograničiti pristup stranici <strong>%0%</strong>]]></key>
+    <key alias="paIsProtected"><![CDATA[<strong>%0%</strong> je sada zaštićen]]></key>
+    <key alias="paIsRemoved"><![CDATA[Zaštita uklonjena sa <strong>%0%</strong>]]></key>
+    <key alias="paLoginPage">Stranica za prijavu</key>
+    <key alias="paLoginPageHelp">Odaberite stranicu koja sadrži obrazac za prijavu</key>
+    <key alias="paRemoveProtection">Uklonite zaštitu...</key>
+    <key alias="paRemoveProtectionConfirm">
+      <![CDATA[Jeste li sigurni da želite ukloniti zaštitu sa stranice <strong>%0%</strong>?]]></key>
+    <key alias="paSelectPages">Odaberite stranice koje sadrže obrazac za prijavu i poruke o greškama</key>
+    <key alias="paSelectGroups"><![CDATA[Odaberite grupe koje imaju pristup stranici <strong>%0%</strong>]]></key>
+    <key alias="paSelectMembers"><![CDATA[Odaberite članove koji imaju pristup stranici <strong>%0%</strong>]]></key>
+    <key alias="paMembers">Posebna zaštita članova</key>
+    <key alias="paMembersHelp">Ako želite dati pristup određenim članovima</key>
+  </area>
+  <area alias="publish">
+    <key alias="contentPublishedFailedAwaitingRelease"><![CDATA[
+      %0% nije mogao biti objavljen jer je stavka zakazana za objavu.
+    ]]>    </key>
+    <key alias="contentPublishedFailedExpired"><![CDATA[
+      %0% nije mogao biti objavljen jer je stavka istekla.
+    ]]>    </key>
+    <key alias="contentPublishedFailedInvalid"><![CDATA[
+      %0% nije moglo biti objavljeno jer ova svojstva:  %1%  nisu prošla pravila validacije.
+    ]]>    </key>
+    <key alias="contentPublishedFailedByEvent"><![CDATA[
+      %0% nije mogao biti objavljen, dodatak treće strane je otkazao radnju.
+    ]]>    </key>
+    <key alias="contentPublishedFailedByParent"><![CDATA[
+      %0% ne može biti objavljena, jer roditeljska stranica nije objavljena.
+    ]]>    </key>
+    <key alias="contentPublishedFailedByMissingName">
+      <![CDATA[%0% ne može se objaviti jer mu nedostaje ime.]]></key>
+    <key alias="includeUnpublished">Uključite neobjavljene podstranice</key>
+    <key alias="inProgress">Objavljivanje u toku - molimo pričekajte...</key>
+    <key alias="inProgressCounter">%0% od %1% stranica je objavljeno...</key>
+    <key alias="nodePublish">%0% je objavljeno</key>
+    <key alias="nodePublishAll">%0% i objavljene su podstranice</key>
+    <key alias="publishAll">Objavi %0% i sve njegove podstranice</key>
+    <key alias="publishHelp"><![CDATA[Pritisni <em>Objavi</em> za objavu <strong>%0%</strong> i na taj način svoj sadržaj učiniti javno dostupnim.<br/><br />
+      Ovu stranicu i sve njene podstranice možete objaviti odabirom <em>Uključi neobjavljene podstranice</em>.
+      ]]>    </key>
+  </area>
+  <area alias="colorpicker">
+    <key alias="noColors">Niste konfigurirali nijednu odobrenu boju</key>
+  </area>
+  <area alias="contentPicker">
+    <key alias="allowedItemTypes">Možete odabrati samo stavke tipa: %0%</key>
+    <key alias="pickedTrashedItem">Odabrali ste stavku sadržaja koja je trenutno obrisana ili je u košu za smeće</key>
+    <key alias="pickedTrashedItems">Odabrali ste stavke sadržaja koje su trenutno obrisane ili su u košu za smeće</key>
+  </area>
+  <area alias="mediaPicker">
+    <key alias="deletedItem">Izbrisana stavka</key>
+    <key alias="pickedTrashedItem">Odabrali ste medijsku stavku koja je trenutno obrisana ili je u košu za smeće</key>
+    <key alias="pickedTrashedItems">Odabrali ste medijske stavke koje su trenutno obrisane ili su u košu za smeće</key>
+    <key alias="trashed">Otpad</key>
+    <key alias="openMedia">Otvorite u biblioteci medija</key>
+    <key alias="changeMedia">Promjena medijske stavke</key>
+    <key alias="editMediaEntryLabel">Uredi %0% od %1%</key>
+    <key alias="confirmCancelMediaEntryCreationHeadline">Odbaci kreiranje?</key>
+    <key alias="confirmCancelMediaEntryCreationMessage"><![CDATA[Jeste li sigurni da želite otkazati kreiranje.]]></key>
+    <key alias="confirmCancelMediaEntryHasChanges">Izmijenili ste ovaj sadržaj. Jeste li sigurni da ga želite
+       odbaciti?
+    </key>
+    <key alias="confirmRemoveAllMediaEntryMessage">Uklonite sve medije?</key>
+    <key alias="tabClipboard">Međuspremnik</key>
+    <key alias="notAllowed">Nije dozvoljeno</key>
+    <key alias="openMediaPicker">Otvorite odabir medija</key>
+  </area>
+  <area alias="relatedlinks">
+    <key alias="enterExternal">unesite vanjski link</key>
+    <key alias="chooseInternal">izaberite internu stranicu</key>
+    <key alias="caption">Naslov</key>
+    <key alias="link">Link</key>
+    <key alias="newWindow">Otvori u novom prozoru</key>
+    <key alias="captionPlaceholder">unesite natpis na ekranu</key>
+    <key alias="externalLinkPlaceholder">Unesite link</key>
+  </area>
+  <area alias="imagecropper">
+    <key alias="reset">Resetirajte izrezivanje</key>
+    <key alias="updateEditCrop">Gotovo</key>
+    <key alias="undoEditCrop">Poništi izmjene</key>
+    <key alias="customCrop">Korisnički definirano</key>
+  </area>
+  <area alias="rollback">
+    <key alias="changes">Promjene</key>
+    <key alias="created">Kreirano</key>
+    <key alias="currentVersion">Trenutna verzija</key>
+    <key alias="diffHelp">
+      <![CDATA[Ovo pokazuje razlike između trenutne verzije i odabrane verzije<br /><del>Crveni tekst</del> bit će uklonjen u odabranoj verziji, <ins>zeleni tekst</ins> će biti dodan]]></key>
+    <key alias="noDiff">Nema razlike između trenutne verzije i odabrane verzije</key>
+    <key alias="documentRolledBack">Dokument je vraćen</key>
+    <key alias="headline">Odaberite verziju koju želite usporediti sa trenutnom verzijom</key>
+    <key alias="htmlHelp">Ovo prikazuje odabranu verziju kao HTML, ako želite vidjeti razliku između dvije
+       verzije u isto vrijeme, koristite pogled diff
+    </key>
+    <key alias="rollbackTo">Vratite se na</key>
+    <key alias="selectVersion">Odaberite verziju</key>
+    <key alias="view">Pogled</key>
+  </area>
+  <area alias="scripts">
+    <key alias="editscript">Uredite datoteku skripte</key>
+  </area>
+  <area alias="sections">
+    <key alias="concierge">Portirnica</key>
+    <key alias="content">Sadržaj</key>
+    <key alias="courier">Kurir</key>
+    <key alias="developer">Developer</key>
+    <key alias="forms">Forme</key>
+    <key alias="help" version="7.0">Pomoć</key>
+    <key alias="installer">Umbraco Konfiguracijski Čarobnjak</key>
+    <key alias="media">Mediji</key>
+    <key alias="member">Članovi</key>
+    <key alias="newsletters">Newsletteri</key>
+    <key alias="packages">Paketi</key>
+    <key alias="marketplace">Marketplace</key>
+    <key alias="settings">Postavke</key>
+    <key alias="statistics">Statistika</key>
+    <key alias="translation">Prijevodi</key>
+    <key alias="users">Korisnici</key>
+  </area>
+  <area alias="help">
+    <key alias="tours">Ture</key>
+    <key alias="theBestUmbracoVideoTutorials">Najbolji Umbraco video tutorijali</key>
+    <key alias="umbracoForum">Posjetite our.umbraco.com</key>
+    <key alias="umbracoTv">Posjetite umbraco.tv</key>
+    <key alias="umbracoLearningBase">Pogledajte naše besplatne video tutorijale</key>
+    <key alias="umbracoLearningBaseDescription">na Umbraco Learning Base</key>
+  </area>
+  <area alias="settings">
+    <key alias="defaulttemplate">Zadani predložak</key>
+    <key alias="importDocumentTypeHelp">Da biste uvezli vrstu dokumenta, pronađite ".udt" datoteku na svom računalu klikom na
+       gumb "Uvezi" (na sljedećem ekranu će se tražiti da potvrdite)
+    </key>
+    <key alias="newtabname">Naslov nove kartice</key>
+    <key alias="nodetype">Tip čvora</key>
+    <key alias="objecttype">Tip</key>
+    <key alias="stylesheet">Stilovi</key>
+    <key alias="script">Skripte</key>
+    <key alias="tab">Kartica</key>
+    <key alias="tabname">Naslov kartice</key>
+    <key alias="tabs">Kartice</key>
+    <key alias="contentTypeEnabled">Glavni tip sadržaja je omogućen</key>
+    <key alias="contentTypeUses">Ovaj tip sadržaja koristi</key>
+    <key alias="noPropertiesDefinedOnTab">Nema definiranih svojstava na ovoj kartici. Kliknite na vezu "dodaj novu nekretninu" na
+       vrh za kreiranje novog svojstva.
+    </key>
+    <key alias="createMatchingTemplate">Kreirajte odgovarajući predložak</key>
+    <key alias="addIcon">Dodaj ikonu</key>
+  </area>
+  <area alias="sort">
+    <key alias="sortOrder">Redoslijed sortiranja</key>
+    <key alias="sortCreationDate">Datum kreiranja</key>
+    <key alias="sortDone">Sortiranje završeno.</key>
+    <key alias="sortHelp">Povucite različite stavke gore ili dolje ispod da postavite kako bi trebale biti raspoređene. Ili kliknite na
+       zaglavlja kolona za sortiranje cijele kolekcije stavki
+    </key>
+    <key alias="sortPleaseWait"><![CDATA[Pričekajte. Stavke se sortiraju, ovo može potrajati.]]></key>
+  </area>
+  <area alias="speechBubbles">
+    <key alias="validationFailedHeader">Validacija</key>
+    <key alias="validationFailedMessage">Greške u validaciji moraju biti ispravljene prije nego što se stavka može spremiti</key>
+    <key alias="operationFailedHeader">Nije uspjelo</key>
+    <key alias="operationSavedHeader">Spremljeno</key>
+    <key alias="invalidUserPermissionsText">Nedovoljne korisničke dozvole, operacija se ne može dovršiti</key>
+    <key alias="operationCancelledHeader">Otkazano</key>
+    <key alias="operationCancelledText">Operaciju je otkazao dodatak treće strane</key>
+    <key alias="folderUploadNotAllowed">Ova datoteka se učitava kao dio fasckile, ali kreiranje nove mape ovdje nije dozvoljeno</key>
+    <key alias="folderCreationNotAllowed">Kreiranje nove mape ovdje nije dozvoljeno</key>
+    <key alias="contentPublishedFailedByEvent">Objavljivanje je otkazao dodatak treće strane</key>
+    <key alias="contentTypeDublicatePropertyType">Tip svojstva već postoji</key>
+    <key alias="contentTypePropertyTypeCreated">Tip svojstva kreiran</key>
+    <key alias="contentTypePropertyTypeCreatedText"><![CDATA[Naziv: %0% <br /> Tip podatka: %1%]]></key>
+    <key alias="contentTypePropertyTypeDeleted">Tip svojstva obrisan</key>
+    <key alias="contentTypeSavedHeader">Tip dokumenta spremljen</key>
+    <key alias="contentTypeTabCreated">Kartica kreirana</key>
+    <key alias="contentTypeTabDeleted">Kartica je obrisana</key>
+    <key alias="contentTypeTabDeletedText">Kartica sa id-em: %0% je obrisana</key>
+    <key alias="cssErrorHeader">Stilovi nisu spremljeni</key>
+    <key alias="cssSavedHeader">Stilovi spremljeni</key>
+    <key alias="cssSavedText">Stilovi spremljeni bez ikakvih grešaka</key>
+    <key alias="dataTypeSaved">Tip podatka spremljen</key>
+    <key alias="dictionaryItemSaved">Stavka riječnika je spremljena</key>
+    <key alias="editContentPublishedFailedByParent">Objavljivanje nije uspjelo jer nadređena stranica nije objavljena</key>
+    <key alias="editContentPublishedHeader">Sadržaj objavljen</key>
+    <key alias="editContentPublishedText">i vidljivo na web stranici</key>
+    <key alias="editBlueprintSavedHeader">Predložak sadržaja je spremljen</key>
+    <key alias="editBlueprintSavedText">Promjene su uspješno spremljene</key>
+    <key alias="editContentSavedHeader">Sadržaj spremljen</key>
+    <key alias="editContentSavedText">Ne zaboravite objaviti da promjene budu vidljive</key>
+    <key alias="editContentSendToPublish">Poslano na odobrenje</key>
+    <key alias="editContentSendToPublishText">Promjene su poslane na odobrenje</key>
+    <key alias="editMediaSaved">Medij spremljen</key>
+    <key alias="editMediaSavedText">Medij spremljen bez ikakvih grešaka</key>
+    <key alias="editMemberSaved">Član spremljen</key>
+    <key alias="editStylesheetPropertySaved">Svojstvo stilova spremljeno</key>
+    <key alias="editStylesheetSaved">Stilovi spremljeni</key>
+    <key alias="editTemplateSaved">Predložak spremljen</key>
+    <key alias="editUserError">Greška pri spremanju korisnika (provjerite log zapis)</key>
+    <key alias="editUserSaved">Korisnik spremljen</key>
+    <key alias="editUserTypeSaved">Tip korisnika spremljen</key>
+    <key alias="editUserGroupSaved">Grupa korisnika spremljena</key>
+    <key alias="editCulturesAndHostnamesSaved">Kulture i imena hostova su spremljeni</key>
+    <key alias="editCulturesAndHostnamesError">Greška pri spremanju kultura i imena hostova</key>
+    <key alias="fileErrorHeader">Datoteka nije spremljena</key>
+    <key alias="fileErrorText">Datoteka nije mogla biti spremljena. Molimo provjerite dozvole za datoteke</key>
+    <key alias="fileSavedHeader">Datoteke spremljene</key>
+    <key alias="fileSavedText">Datoteka spremljena bez ikakvih grešaka</key>
+    <key alias="languageSaved">Jezik spremljen</key>
+    <key alias="mediaTypeSavedHeader">Tip medija spremljen</key>
+    <key alias="memberTypeSavedHeader">Tip člana spremljen</key>
+    <key alias="memberGroupSavedHeader">Grupa članova spremljena</key>
+    <key alias="memberGroupNameDuplicate">Druga grupa članova sa istim imenom već postoji</key>
+    <key alias="templateErrorHeader">Predložak nije spremljen</key>
+    <key alias="templateErrorText">Uvjerite se da nemate 2 predloška sa istim aliasom</key>
+    <key alias="templateSavedHeader">Predložak spremljen</key>
+    <key alias="templateSavedText">Predložak spremljen bez ikakvih grešaka!</key>
+    <key alias="contentUnpublished">Sadržaj nije objavljen</key>
+    <key alias="partialViewSavedHeader">Parcijalni prikaz spremljen</key>
+    <key alias="partialViewSavedText">Parcijalni prikaz spremljen bez ikakvih grešaka!</key>
+    <key alias="partialViewErrorHeader">Parcijalni prikaz nije spremljen</key>
+    <key alias="partialViewErrorText">Došlo je do greške prilikom spremanja datoteke.</key>
+    <key alias="permissionsSavedFor">Dozvole su spremljene za</key>
+    <key alias="deleteUserGroupsSuccess">Izbrisano je %0% grupa korisnika</key>
+    <key alias="deleteUserGroupSuccess">%0% je obrisano</key>
+    <key alias="enableUsersSuccess">Omogućeno %0% korisnika</key>
+    <key alias="disableUsersSuccess">Onemogućeno %0% korisnika</key>
+    <key alias="enableUserSuccess">%0% je sada omogućen</key>
+    <key alias="disableUserSuccess">%0% je sada onemogućen</key>
+    <key alias="setUserGroupOnUsersSuccess">Grupe korisnika su postavljene</key>
+    <key alias="unlockUsersSuccess">Otključano %0% korisnika</key>
+    <key alias="unlockUserSuccess">%0% je sada otključan</key>
+    <key alias="memberExportedSuccess">Član je izvezen u datoteku</key>
+    <key alias="memberExportedError">Došlo je do greške prilikom izvoza člana</key>
+    <key alias="deleteUserSuccess">Korisnik %0% je obrisan</key>
+    <key alias="resendInviteHeader">Pozovi korisnika</key>
+    <key alias="resendInviteSuccess">Pozivnica je ponovo poslana na %0%</key>
+    <key alias="documentTypeExportedSuccess">Tip dokumenta je izvezen u datoteku</key>
+    <key alias="documentTypeExportedError">Došlo je do greške prilikom izvoza tipa dokumenta</key>
+    <key alias="dictionaryItemExportedSuccess">Stavke iz riječnika su izvezene u datoteku</key>
+    <key alias="dictionaryItemExportedError">Došlo je do greške prilikom izvoza stavki rječnika</key>
+    <key alias="dictionaryItemImported">Sljedeće stavke iz rječnika su uvezene!</key>
+    <key alias="publishWithNoDomains">Domene nisu konfigurirane za višejezične stranice, molimo kontaktirajte administratora,
+       pogledajte log zapise za više informacija
+    </key>
+    <key alias="publishWithMissingDomain">Nijedna domena nije konfigurirana za %0%, molimo kontaktirajte administratora</key>
+    <key alias="copySuccessMessage">Vaše sistemske informacije su uspješno kopirane u međuspremnik</key>
+    <key alias="cannotCopyInformation">Nije moguće kopirati vaše sistemske informacije u međuspremnik</key>
+  </area>
+  <area alias="stylesheet">
+    <key alias="addRule">Dodaj stil</key>
+    <key alias="editRule">Uredi stil</key>
+    <key alias="editorRules">Stilovi za uređivanje bogatog teksta</key>
+    <key alias="editorRulesHelp">Definirajte stilove koji bi trebali biti dostupni u uređivaču obogaćenog teksta za ove
+	   stilove
+    </key>
+    <key alias="editstylesheet">Uredi stilove</key>
+    <key alias="editstylesheetproperty">Uredi svojstvo stilova</key>
+    <key alias="nameHelp">Ime prikazano u uređivaču odabira stilova</key>
+    <key alias="preview">Pregled</key>
+    <key alias="previewHelp">Kako će tekst izgledati u uređivaču obogaćenog teksta.</key>
+    <key alias="selector">Selektor</key>
+    <key alias="selectorHelp">Koristite CSS sintaksu, npr. "h1" ili ".redHeader"</key>
+    <key alias="styles">Stilovi</key>
+    <key alias="stylesHelp">CSS koji treba primijeniti u uređivaču obogaćenog teksta, npr. "color:red;"</key>
+    <key alias="tabCode">Kod</key>
+    <key alias="tabRules">Uređivač</key>
+  </area>
+  <area alias="template">
+    <key alias="runtimeModeProduction"><![CDATA[Sadržaj se ne može uređivati kada se koristi način rada <code>Produkcija</code>.]]></key>
+    <key alias="deleteByIdFailed">Brisanje predloška sa ID-om %0% nije uspjelo</key>
+    <key alias="edittemplate">Uredi predložak</key>
+    <key alias="insertSections">Sekcije</key>
+    <key alias="insertContentArea">Umetnite područje sadržaja</key>
+    <key alias="insertContentAreaPlaceHolder">Umetnite čuvara mjesta u području sadržaja</key>
+    <key alias="insert">Umetni</key>
+    <key alias="insertDesc">Odaberite što ćete umetnuti u svoj predložak</key>
+    <key alias="insertDictionaryItem">Stavka iz rječnika</key>
+    <key alias="insertDictionaryItemDesc">Stavka rječnika je čuvar mjesta za prevodljiv dio teksta, koji
+       olakšava kreiranje dizajna za višejezične web stranice.
+    </key>
+    <key alias="insertMacro">Makro</key>
+    <key alias="insertMacroDesc">
+       Makro je komponenta koja se može konfigurirati i odlična je za
+       višenamjenske dijelove vašeg dizajna, gdje vam je potrebna opcija za pružanje parametara,
+       kao što su galerije, obrasci i liste.
+    </key>
+    <key alias="insertPageField">Vrijednost</key>
+    <key alias="insertPageFieldDesc">Prikazuje vrijednost polja sa trenutne stranice po aliasu s opcijama za izmjenu vrijednosti ili povratak na alternativne vrijednosti.</key>
+    <key alias="insertPartialView">Parcijalni prikaz</key>
+    <key alias="insertPartialViewDesc">
+       Parcijalni prikaz je zasebna datoteka predloška koja se može prikazati unutar drugog
+       predložka, odličan je za ponovnu upotrebu markupa ili za odvajanje složenih predložaka u zasebne datoteke.
+    </key>
+    <key alias="mastertemplate">Glavni predložak</key>
+    <key alias="noMaster">Nema glavnog predloška</key>
+    <key alias="renderBody">Renderirajte podređeni predložak</key>
+    <key alias="renderBodyDesc"><![CDATA[
+     Renderira sadržaj podređenog predloška, umetanjem
+     <code>@RenderBody()</code>.
+      ]]>    </key>
+    <key alias="defineSection">Definirajte imenovanu sekciju</key>
+    <key alias="defineSectionDesc"><![CDATA[
+         Definira dio vašeg predloška kao imenovanu sekciju tako što ga umotava
+          <code>@section { ... }</code>. Ovo se može prikazati u
+           određenom području nadređenog predloška, koristeći <code>@RenderSection</code>.
+      ]]>    </key>
+    <key alias="renderSection">Renderirajte imenovanu sekciju</key>
+    <key alias="renderSectionDesc"><![CDATA[
+      Renderira imenovano područje podređenog predloška, umetanjem <code>@RenderSection(name)</code>.
+      Ovo prikazuje područje podređenog predloška koje je umotano u odgovarajuću <code>@section [name]{ ... }</code> definiciju.
+      ]]>    </key>
+    <key alias="sectionName">Naziv sekcije</key>
+    <key alias="sectionMandatory">Sekcija je obavezna</key>
+    <key alias="sectionMandatoryDesc"><![CDATA[
+            Ako je obavezno, podređeni predložak mora sadržavati <code>@section</code>, u suprotnom se prikazuje greška.
+    ]]>    </key>
+    <key alias="queryBuilder">Generiranje upita</key>
+    <key alias="itemsReturned">stavaka vraćeno, u</key>
+    <key alias="iWant">Želim</key>
+    <key alias="allContent">sav sadržaj</key>
+    <key alias="contentOfType">sadržaj tipa "%0%"</key>
+    <key alias="from">sa</key>
+    <key alias="websiteRoot">moje web stranice</key>
+    <key alias="where">gdje</key>
+    <key alias="and">i</key>
+    <key alias="is">je</key>
+    <key alias="isNot">nije</key>
+    <key alias="before">prije</key>
+    <key alias="beforeIncDate">prije (uključujući odabrani datum)</key>
+    <key alias="after">poslije</key>
+    <key alias="afterIncDate">poslije (uključujući odabrani datum)</key>
+    <key alias="equals">jednako</key>
+    <key alias="doesNotEqual">nije jednako</key>
+    <key alias="contains">sadrži</key>
+    <key alias="doesNotContain">ne sadrži</key>
+    <key alias="greaterThan">veće od</key>
+    <key alias="greaterThanEqual">veće ili jednako</key>
+    <key alias="lessThan">manje od</key>
+    <key alias="lessThanEqual">manje ili jednako</key>
+    <key alias="id">Id</key>
+    <key alias="name">Naziv</key>
+    <key alias="createdDate">Kreirano</key>
+    <key alias="lastUpdatedDate">Ažurirano</key>
+    <key alias="orderBy">poredaj po</key>
+    <key alias="ascending">uzlazno</key>
+    <key alias="descending">silazno</key>
+    <key alias="template">Predložak</key>
+  </area>
+  <area alias="grid">
+    <key alias="media">Slika</key>
+    <key alias="macro">Makro</key>
+    <key alias="insertControl">Odaberite tip sadržaja</key>
+    <key alias="chooseLayout">Odaberite izgled</key>
+    <key alias="addRows">Dodaj redak</key>
+    <key alias="addElement">Dodaj sadržaj</key>
+    <key alias="dropElement">Ispusti sadržaj</key>
+    <key alias="settingsApplied">Postavke su primijenjene</key>
+    <key alias="contentNotAllowed">Ovaj sadržaj ovdje nije dozvoljen</key>
+    <key alias="contentAllowed">Ovaj sadržaj je ovdje dozvoljen</key>
+    <key alias="clickToEmbed">Kliknite za ugradnju</key>
+    <key alias="clickToInsertImage">Kliknite da umetnete sliku</key>
+    <key alias="clickToInsertMacro">Kliknite da umetnete makro</key>
+    <key alias="placeholderWriteHere">Pišite ovdje...</key>
+    <key alias="gridLayouts">Raspored mreže</key>
+    <key alias="gridLayoutsDetail">Izgledi su cjelokupno radno područje za uređivač mreže, obično vam je potreban samo jedan ili
+       dva različita izgleda
+    </key>
+    <key alias="addGridLayout">Dodajte raspored mreže</key>
+    <key alias="editGridLayout">Uredite raspored mreže</key>
+    <key alias="addGridLayoutDetail">Prilagodite izgled postavljanjem širine kolona i dodavanjem dodatnih odjeljaka</key>
+    <key alias="rowConfigurations">Konfiguracije redova</key>
+    <key alias="rowConfigurationsDetail">Redovi su predefinirani za raspored vodoravno</key>
+    <key alias="addRowConfiguration">Dodajte konfiguraciju reda</key>
+    <key alias="editRowConfiguration">Uredite konfiguraciju reda</key>
+    <key alias="addRowConfigurationDetail">Podesite red postavljanjem širine ćelija i dodavanjem dodatnih ćelija</key>
+    <key alias="noConfiguration">Nije dostupna dodatna konfiguracija</key>
+    <key alias="columns">Kolone</key>
+    <key alias="columnsDetails">Ukupan kombinirani broj kolona u rasporedu mreže</key>
+    <key alias="settings">Postavke</key>
+    <key alias="settingsDetails">Konfigurirajte koje postavke urednici mogu promijeniti</key>
+    <key alias="styles">Stilovi</key>
+    <key alias="stylesDetails">Konfigurirajte šta uređivači stilova mogu promijeniti</key>
+    <key alias="allowAllEditors">Dozvoli svim urednicima</key>
+    <key alias="allowAllRowConfigurations">Dozvoli sve konfiguracije redaka</key>
+    <key alias="maxItems">Maksimalan broj stavki</key>
+    <key alias="maxItemsDescription">Ostavite prazno ili postavite na 0 za neograničeno</key>
+    <key alias="setAsDefault">Postavi kao zadano</key>
+    <key alias="chooseExtra">Odaberite extra</key>
+    <key alias="chooseDefault">Odaberite zadano</key>
+    <key alias="areAdded">su dodani</key>
+    <key alias="warning">Upozorenje</key>
+    <key alias="warningText">
+      <![CDATA[<p>Promjena imena konfiguracije reda će rezultirati gubitkom podataka za bilo koji postojeći sadržaj koji se temelji na ovoj konfiguraciji.</p> <p><strong>Izmjena samo oznake neće rezultirati gubitkom podataka.</strong></p>]]></key>
+    <key alias="youAreDeleting">Brišete konfiguraciju reda</key>
+    <key alias="deletingARow">
+      Brisanje imena konfiguracije reda će rezultirati gubitkom podataka za bilo koji postojeći sadržaj koji je zasnovan na ovome
+      konfiguraciju.
+    </key>
+    <key alias="deleteLayout">Brišete izgled</key>
+    <key alias="deletingALayout">Izmjena izgleda će rezultirati gubitkom podataka za bilo koji postojeći sadržaj koji je zasnovan
+       na ovoj konfiguraciji.
+    </key>
+  </area>
+  <area alias="contentTypeEditor">
+    <key alias="compositions">Kompozicije</key>
+    <key alias="group">Grupa</key>
+    <key alias="noGroups">Niste dodali nijednu grupu</key>
+    <key alias="addGroup">Dodaj grupu</key>
+    <key alias="inheritedFrom">Naslijeđeno od</key>
+    <key alias="addProperty">Dodaj svojstvo</key>
+    <key alias="requiredLabel">Obavezna oznaka</key>
+    <key alias="enableListViewHeading">Omogući prikaz liste</key>
+    <key alias="enableListViewDescription">Konfigurira stavku sadržaja da prikaže njenu listu koja se može sortirati i pretraživati djecu, djeca neće biti prikazana u stablu
+    </key>
+    <key alias="allowedTemplatesHeading">Dozvoljeni predlošci</key>
+    <key alias="allowedTemplatesDescription">Odaberite koje predloške urednici mogu koristiti na sadržaju ove vrste
+    </key>
+    <key alias="allowAsRootHeading">Dozvoli kao korijen</key>
+    <key alias="allowAsRootDescription">Dozvolite urednicima da kreiraju sadržaj ovog tipa u korijenu stabla sadržaja.
+    </key>
+    <key alias="childNodesHeading">Dozvoljeni tipovi podređenih čvorova</key>
+    <key alias="childNodesDescription">Dozvolite da se sadržaj navedenih tipova kreira ispod sadržaja ovog tipa.
+    </key>
+    <key alias="chooseChildNode">Odaberite podređeni čvor</key>
+    <key alias="compositionsDescription">Naslijediti kartice i svojstva iz postojeće vrste dokumenta. Nove kartice bit će
+      dodane trenutnoj vrsti dokumenta ili spojene ako postoji kartica s identičnim imenom.
+    </key>
+    <key alias="compositionInUse">Ovaj tip sadržaja se koristi u kompoziciji i stoga se ne može sam sastaviti.
+    </key>
+    <key alias="noAvailableCompositions">Nema dostupnih tipova sadržaja za upotrebu kao kompozicija.</key>
+    <key alias="compositionRemoveWarning">Uklanjanje kompozicije će obrisati sve povezane podatke o svojstvu. Jednom kada spremite tip dokumenta, nema povratka.
+    </key>
+    <key alias="availableEditors">Napravi novi</key>
+    <key alias="reuse">Koristite postojeće</key>
+    <key alias="editorSettings">Postavke urednika</key>
+    <key alias="configuration">Konfiguracija</key>
+    <key alias="yesDelete">Da, izbriši</key>
+    <key alias="movedUnderneath">je premještena ispod</key>
+    <key alias="copiedUnderneath">je kopirano ispod</key>
+    <key alias="folderToMove">Odaberite mapu za premještanje</key>
+    <key alias="folderToCopy">Odaberite mapu za kopiranje</key>
+    <key alias="structureBelow">do u strukturi stabla ispod</key>
+    <key alias="allDocumentTypes">Svi tipovi dokumenata</key>
+    <key alias="allDocuments">Svi dokumenti</key>
+    <key alias="allMediaItems">Sve medijske stavke</key>
+    <key alias="usingThisDocument">korištenje ovog tipa dokumenta bit će trajno izbrisano, potvrdite da želite obrisati ove također.</key>
+    <key alias="usingThisMedia">korištenje ove vrste medija će biti trajno izbrisano, potvrdite da želite obrisati ove također.
+    </key>
+    <key alias="usingThisMember">korištenje ove vrste člana će biti trajno izbrisano, potvrdite da želite obrisati ove također</key>
+    <key alias="andAllDocuments">i svi dokumenti koji koriste ovu vrstu</key>
+    <key alias="andAllMediaItems">i sve medijske stavke koje koriste ovu vrstu</key>
+    <key alias="andAllMembers">i svi članovi koji koriste ovaj tip</key>
+    <key alias="memberCanEdit">Član može uređivati</key>
+    <key alias="memberCanEditDescription">Dozvolite da ovu vrijednost svojstva da uređuje član na svojoj stranici profila
+    </key>
+    <key alias="isSensitiveData">Osjetljivi podaci</key>
+    <key alias="isSensitiveDataDescription">Sakrij ovu vrijednost svojstva od urednika sadržaja koji nemaju pristup pregledu
+      osjetljive informacije
+    </key>
+    <key alias="showOnMemberProfile">Prikaži na profilu člana</key>
+    <key alias="showOnMemberProfileDescription">Dozvolite da se ova vrijednost svojstva prikaže na stranici profila člana
+    </key>
+    <key alias="tabHasNoSortOrder">kartica nema redoslijed sortiranja</key>
+    <key alias="compositionUsageHeading">Gdje se koristi ovaj sastav?</key>
+    <key alias="compositionUsageSpecification">Ovaj sastav se trenutno koristi u sastavu sljedećih
+      tipa sadržaja:
+    </key>
+    <key alias="variantsHeading">Dozvoli varijacije</key>
+    <key alias="cultureVariantHeading">Dozvolite varirati u zavisnosti od kulture</key>
+    <key alias="segmentVariantHeading">Dozvoli segmentaciju</key>
+    <key alias="cultureVariantLabel">Varijacije po kulturi</key>
+    <key alias="segmentVariantLabel">Varijacije po segmentima</key>
+    <key alias="variantsDescription">Dozvolite urednicima da kreiraju sadržaj ove vrste na različitim jezicima.</key>
+    <key alias="cultureVariantDescription">Dozvolite urednicima da kreiraju sadržaj na različitim jezicima.</key>
+    <key alias="segmentVariantDescription">Dozvolite urednicima da kreiraju segmente ovog sadržaja.</key>
+    <key alias="allowVaryByCulture">Dozvolite varijaciju po kulturi</key>
+    <key alias="allowVaryBySegment">Dozvoli segmentaciju</key>
+    <key alias="elementType">Tip elementa</key>
+    <key alias="elementHeading">Je li tip elementa</key>
+    <key alias="elementDescription">Tip elementa je namijenjen za korištenje na primjer u ugniježđenom sadržaju, a ne u stablu.
+    </key>
+    <key alias="elementCannotToggle">Tip dokumenta se ne može promijeniti u tip elementa nakon što je naviknut
+      kreirati jednu ili više stavki sadržaja.
+    </key>
+    <key alias="elementDoesNotSupport">Ovo nije primjenjivo za tip elementa</key>
+    <key alias="propertyHasChanges">Napravili ste promjene on ovom svojstvu. Jeste li sigurni da ih želite odbaciti?</key>
+    <key alias="displaySettingsHeadline">Izgled</key>
+    <key alias="displaySettingsLabelOnTop">Oznaka iznad (puna širina)</key>
+    <key alias="removeChildNode">Uklanjate podređeni čvor</key>
+    <key alias="removeChildNodeWarning">Uklanjanje podređenog čvora ograničit će opcije urednika da kreiraju drugačiji sadržaj
+      tipovi ispod čvora.
+    </key>
+    <key alias="usingEditor">korištenjem ovog uređivača bit će ažurirane nove postavke.</key>
+    <key alias="historyCleanupHeading">Brisanje povijesti</key>
+    <key alias="historyCleanupDescription">Dozvoli zaobilaženje postavki čišćenja globalne povijesti.</key>
+    <key alias="historyCleanupKeepAllVersionsNewerThanDays">Neka sve verzije budu novije od dana</key>
+    <key alias="historyCleanupKeepLatestVersionPerDayForDays">Čuvajte najnoviju verziju po danu danima</key>
+    <key alias="historyCleanupPreventCleanup">Spriječi čišćenje</key>
+    <key alias="historyCleanupEnableCleanup">Omogući čišćenje</key>
+    <key alias="historyCleanupGloballyDisabled"><![CDATA[<strong>BILJEŠKA!</strong> Čišćenje povijesnih verzija sadržaja onemogućeno je globalno. Ove postavke neće stupiti na snagu prije nego što se omogući.]]></key>
+  </area>
+  <area alias="languages">
+    <key alias="addLanguage">Dodaj jezik</key>
+    <key alias="culture">ISO kod</key>
+    <key alias="mandatoryLanguage">Obavezan jezik</key>
+    <key alias="mandatoryLanguageHelp">Svojstva na ovom jeziku moraju biti popunjena prije nego što se čvor može objaviti.
+    </key>
+    <key alias="defaultLanguage">Zadani jezik</key>
+    <key alias="defaultLanguageHelp">Umbraco stranica može imati samo jedan zadani jezik.</key>
+    <key alias="changingDefaultLanguageWarning">Promjena zadanog jezika može rezultirati nedostatkom zadanog sadržaja.</key>
+    <key alias="fallsbackToLabel">Vraća se na</key>
+    <key alias="noFallbackLanguageOption">Nema zamjenskog jezika</key>
+    <key alias="fallbackLanguageDescription">Da se omogući višejezični sadržaj da se vrati na drugi jezik ako ne
+      bude prisutan na traženom jeziku, odaberite ga ovdje.
+    </key>
+    <key alias="fallbackLanguage">Zamjenski jezik</key>
+    <key alias="none">niti jedan</key>
+  </area>
+  <area alias="macro">
+    <key alias="addParameter">Dodaj parameter</key>
+    <key alias="editParameter">Uredi parameter</key>
+    <key alias="enterMacroName">Unesite naziv makroa</key>
+    <key alias="parameters">Parametri</key>
+    <key alias="parametersDescription">Definirajte parametre koji bi trebali biti dostupni kada koristite ovaj makro.</key>
+    <key alias="selectViewFile">Odaberite parcijalni prikaz makro datoteke</key>
+  </area>
+  <area alias="modelsBuilder">
+    <key alias="buildingModels">Kreiranje modela</key>
+    <key alias="waitingMessage">ovo može potrajati, ne brinite</key>
+    <key alias="modelsGenerated">Modeli generirani</key>
+    <key alias="modelsGeneratedError">Modeli ne mogu biti generirani</key>
+    <key alias="modelsExceptionInUlog">Generiranje modela nije uspjelo, pogledajte iznimku u log zapisima</key>
+  </area>
+  <area alias="templateEditor">
+    <key alias="addDefaultValue">Dodajte zadanu vrijednost</key>
+    <key alias="defaultValue">Zadana vrijednost</key>
+    <key alias="alternativeField">Rezervno polje</key>
+    <key alias="alternativeText">Zadana vrijednost</key>
+    <key alias="casing">Veličina slova</key>
+    <key alias="encoding">Kodiranje</key>
+    <key alias="chooseField">Odaberite polje</key>
+    <key alias="convertLineBreaks">Pretvorite prijelome redaka</key>
+    <key alias="convertLineBreaksHelp">Zamjenjuje prijelome reda sa 'br' html oznakom</key>
+    <key alias="customFields">Prilagođena polja</key>
+    <key alias="dateOnly">Samo datum</key>
+    <key alias="formatAsDate">Formatiraj kao datum</key>
+    <key alias="htmlEncode">Kodirati kao HTML</key>
+    <key alias="htmlEncodeHelp">Zamijenit će specijalne znakove njihovim HTML ekvivalentom.</key>
+    <key alias="insertedAfter">Bit će umetnuto iza vrednosti polja</key>
+    <key alias="insertedBefore">Bit će umetnuto ispred vrednosti polja</key>
+    <key alias="lowercase">Mala slova</key>
+    <key alias="none">Nema</key>
+    <key alias="outputSample">Izlazni uzorak</key>
+    <key alias="postContent">Umetnuti nakon polja</key>
+    <key alias="preContent">Umetnuti ispred polja</key>
+    <key alias="recursive">Rekurzivno</key>
+    <key alias="recursiveDescr">Da, neka bude rekurzivno</key>
+    <key alias="standardFields">Standardna polja</key>
+    <key alias="uppercase">Velika slova</key>
+    <key alias="urlEncode">Kodirati kao URL</key>
+    <key alias="urlEncodeHelp">Formatirat će posebne znakove u URL-ovima</key>
+    <key alias="usedIfAllEmpty">Koristit će se samo kada su vrijednosti polja iznad prazne</key>
+    <key alias="usedIfEmpty">Ovo polje će se koristiti samo ako je primarno polje prazno</key>
+    <key alias="withTime">Datum i vrijeme</key>
+  </area>
+  <area alias="translation">
+    <key alias="details">Detalji prijevoda</key>
+    <key alias="DownloadXmlDTD">Preuzmi XML DTD</key>
+    <key alias="fields">Polja</key>
+    <key alias="includeSubpages">Uključi podstranice</key>
+    <key alias="mailBody"><![CDATA[
+      Zdravo %0%
+
+      Ovo je automatska pošta koja vas obavještava da je za 
+	  dokument '%1%' zatražen prijevod na '%5%' od %2%.
+
+      Idi na http://%3%/translation/details.aspx?id=%4% za uređivanje.
+
+      Ili se prijavite na Umbraco da bi dobili pregled vaših zadataka za prijevod
+      http://%3%
+
+      Ugodan dan!
+      Pozdrav od Umbraco robota
+    ]]>    </key>
+    <key alias="noTranslators">Nije pronađen niti jedan korisnik prevoditelja. Molimo kreirajte korisnika prevoditelja prije nego počnete slati
+       sadržaj u prijevod
+    </key>
+    <key alias="pageHasBeenSendToTranslation">Stranica '%0%' je poslana na prijevod</key>
+    <key alias="sendToTranslate">Pošaljite stranicu '%0%' na prijevod</key>
+    <key alias="totalWords">Ukupno riječi</key>
+    <key alias="translateTo">Prevedi na</key>
+    <key alias="translationDone">Prijevod završen.</key>
+    <key alias="translationDoneHelp">Možete pregledati stranice koje ste upravo preveli klikom ispod. </key>
+    <key alias="translationFailed">Prijevod nije uspio, XML datoteka je možda oštećena</key>
+    <key alias="translationOptions">Opcije prevođenja</key>
+    <key alias="translator">Prevoditelj</key>
+    <key alias="uploadTranslationXml">Uvezite XML prijevod</key>
+  </area>
+  <area alias="treeHeaders">
+    <key alias="content">Sadržaj</key>
+    <key alias="contentBlueprints">Predlošci sadržaja</key>
+    <key alias="media">Mediji</key>
+    <key alias="cacheBrowser">Pretraživač predmemorije</key>
+    <key alias="contentRecycleBin">Koš za smeće</key>
+    <key alias="createdPackages">Kreirani paketi</key>
+    <key alias="dataTypes">Tipovi podataka</key>
+    <key alias="dictionary">Riječnik</key>
+    <key alias="installedPackages">Instalirani paketi</key>
+    <key alias="installSkin">Instaliraj skin</key>
+    <key alias="installStarterKit">Instaliraj starter kit</key>
+    <key alias="languages">Jezici</key>
+    <key alias="localPackage">Instaliraj lokalni paket</key>
+    <key alias="macros">Makroi</key>
+    <key alias="mediaTypes">Tipovi medija</key>
+    <key alias="member">Članovi</key>
+    <key alias="memberGroups">Grupe članova</key>
+    <key alias="memberRoles">Uloge članova</key>
+    <key alias="memberTypes">Tipovi članova</key>
+    <key alias="documentTypes">Tipovi dokumenata</key>
+    <key alias="relationTypes">Tipovi relacija</key>
+    <key alias="packager">Paketi</key>
+    <key alias="packages">Paketi</key>
+    <key alias="partialViews">Parcijalni pogledi</key>
+    <key alias="partialViewMacros">Parcijalni pregledi makro datoteka</key>
+    <key alias="repositories">Instaliraj iz repozitorija</key>
+    <key alias="runway">Instaliraj Runway</key>
+    <key alias="runwayModules">Runway moduli</key>
+    <key alias="scripting">Skripte</key>
+    <key alias="scripts">Skripte</key>
+    <key alias="stylesheets">Stilovi</key>
+    <key alias="templates">Predlošci</key>
+    <key alias="logViewer">Log preglednik</key>
+    <key alias="users">Korisnici</key>
+    <key alias="settingsGroup">Postavke</key>
+    <key alias="templatingGroup">Predložak</key>
+    <key alias="thirdPartyGroup">Treća strana</key>
+  </area>
+  <area alias="update">
+    <key alias="updateAvailable">Postoji nova verzija</key>
+    <key alias="updateDownloadText">%0% je spremno, kliknite ovdje za preuzimanje</key>
+    <key alias="updateNoServer">Veza sa serverom je prekinuta</key>
+    <key alias="updateNoServerError">Pogreška prilikom provjeravanja ažuriranja. Za dodtne informacije provjerite trace-stack</key>
+  </area>
+  <area alias="user">
+    <key alias="access">Pristup</key>
+    <key alias="accessHelp">Na temelju dodijeljenih grupa i početnih čvorova, korisnik ima pristup sljedećim čvorovima
+    </key>
+    <key alias="assignAccess">Dodijeli pristup</key>
+    <key alias="administrators">Administrator</key>
+    <key alias="categoryField">Polje kategorije</key>
+    <key alias="createDate">Korisnik kreiran</key>
+    <key alias="changePassword">Promijeni lozinku</key>
+    <key alias="changePhoto">Promijeni sliku</key>
+    <key alias="newPassword">Nova lozinka</key>
+    <key alias="newPasswordFormatLengthTip">Najmanje %0% znakova!</key>
+    <key alias="newPasswordFormatNonAlphaTip">Trebalo bi biti najmanje %0% specijalnih znakova.</key>
+    <key alias="noLockouts">nije zaključan</key>
+    <key alias="noPasswordChange">Lozinka nije promijenjena</key>
+    <key alias="confirmNewPassword">Potvrdite novu lozinku</key>
+    <key alias="changePasswordDescription">Možete promijeniti svoju lozinku za pristup Umbraco Back Officeu tako da ispunite donji obrazac i kliknete gumb "Promjeni lozinku"</key>
+    <key alias="contentChannel">Kanal sadržaja</key>
+    <key alias="createAnotherUser">Kreiraj drugog korisnika</key>
+    <key alias="createUserHelp">Kreirajte nove korisnike kako biste im omogućili pristup Umbraco-u. Kada se kreira novi korisnik, stvorit će se lozinka koju možete podijeliti s korisnikom.
+    </key>
+    <key alias="descriptionField">Polje kratkog opisa</key>
+    <key alias="disabled">Onemogući korisnika</key>
+    <key alias="documentType">Tip dokumenta</key>
+    <key alias="editors">Urednik</key>
+    <key alias="emailRequired">Obavezno - unesite email adresu za ovog korisnika</key>
+    <key alias="excerptField">Polje izvoda</key>
+    <key alias="failedPasswordAttempts">Neuspjeli pokušaji prijave</key>
+    <key alias="goToProfile">Idite na korisnički profil</key>
+    <key alias="groupsHelp">Dodajte grupe za dodjelu pristupa i dozvola</key>
+    <key alias="inviteAnotherUser">Pozovite drugog korisnika</key>
+    <key alias="inviteUserHelp">Pozovite nove korisnike da im omogućite pristup Umbraco-u. Korisniku bit će poslan email s pozivnicom i informacijama o tome kako se prijaviti u Umbraco. Pozivnice traju 72 sata.
+    </key>
+    <key alias="language">Jezik</key>
+    <key alias="languageHelp">Postavite jezik koji ćete vidjeti u izbornicima i dijaloškim okvirima</key>
+    <key alias="lastLockoutDate">Zadnji datum zaključavanja</key>
+    <key alias="lastLogin">Zadnja prijava</key>
+    <key alias="lastPasswordChangeDate">Lozinka zadnje promijenjena</key>
+    <key alias="loginname">Korisničko ime</key>
+    <key alias="mediastartnode">Medijski početni čvor</key>
+    <key alias="mediastartnodehelp">Ograničite biblioteku medija na određeni početni čvor</key>
+    <key alias="mediastartnodes">Medijski početni čvorovi</key>
+    <key alias="mediastartnodeshelp">Ograničite biblioteku medija na određene početne čvorove</key>
+    <key alias="modules">Sekcije</key>
+    <key alias="nameRequired">Obavezno - unesite ime za ovog korisnika</key>
+    <key alias="noConsole">Onemogućite pristup Umbraco-u</key>
+    <key alias="noLogin">se još nije prijavio</key>
+    <key alias="oldPassword">Stara lozinka</key>
+    <key alias="password">Lozinka</key>
+    <key alias="resetPassword">Resetiraj lozinku</key>
+    <key alias="passwordChanged">Vaša lozinka je promijenjena!</key>
+    <key alias="passwordChangedGeneric">Lozinka je promijenjena</key>
+    <key alias="passwordConfirm">Molimo potvrdite novu lozinku</key>
+    <key alias="passwordEnterNew">Unesite novu lozinku</key>
+    <key alias="passwordIsBlank">Vaša nova lozinka ne može biti prazna!</key>
+    <key alias="passwordCurrent">Trenutna lozinka</key>
+    <key alias="passwordInvalid">Nevažeća trenutna lozinka</key>
+    <key alias="passwordIsDifferent">Postoji razlika između nove lozinke i potvrđene lozinke. Molimo pokušajte ponovo!</key>
+    <key alias="passwordMismatch">Potvrđena lozinka ne odgovara novoj lozinki!</key>
+    <key alias="permissionReplaceChildren">Zamijenite dozvole podređenog čvora</key>
+    <key alias="permissionSelectedPages">Trenutno mijenjate dozvole za stranice:</key>
+    <key alias="permissionSelectPages">Odaberite stranice da promijenite njihove dozvole</key>
+    <key alias="removePhoto">Ukloni sliku</key>
+    <key alias="permissionsDefault">Zadane dozvole</key>
+    <key alias="permissionsGranular">Detaljne dozvole</key>
+    <key alias="permissionsGranularHelp">Postavite dozvole za određene čvorove</key>
+    <key alias="profile">Profil</key>
+    <key alias="searchAllChildren">Pretražite svu djecu</key>
+    <key alias="languagesHelp">Ograničite jezike kojima korisnici imaju pristup za uređivanje</key>
+    <key alias="sectionsHelp">Dodajte odjeljke da korisnicima omogućite pristup</key>
+    <key alias="selectUserGroups">Odaberite grupe korisnika</key>
+    <key alias="noStartNode">Nije odabran početni čvor</key>
+    <key alias="noStartNodes">Nije odabran nijedan početni čvor</key>
+    <key alias="startnode">Početni čvor sadržaja</key>
+    <key alias="startnodehelp">Ograničite stablo sadržaja na određeni početni čvor</key>
+    <key alias="startnodes">Početni čvorovi sadržaja</key>
+    <key alias="startnodeshelp">Ograničite stablo sadržaja na određene početne čvorove</key>
+    <key alias="updateDate">Korisnik zadnji put ažuriran</key>
+    <key alias="userCreated">je kreiran</key>
+    <key alias="userCreatedSuccessHelp">Novi korisnik je uspješno kreiran. Za prijavu na Umbraco koristite
+      lozinka ispod.
+    </key>
+    <key alias="userManagement">Upravljanje korisnicima</key>
+    <key alias="username">Korisničko ime</key>
+    <key alias="userPermissions">Korisničke dozvole</key>
+    <key alias="usergroup">Grupa korisnika</key>
+    <key alias="userInvited">je pozvan</key>
+    <key alias="userInvitedSuccessHelp">Novom korisniku je poslana pozivnica s detaljima o tome kako se prijaviti u Umbraco.</key>
+    <key alias="userinviteWelcomeMessage">Pozdrav i dobrodošli u Umbraco! Jedna minuta bit će vam potrebna da postavite svoju lozinku i dodate svoju profilnu sliku.</key>
+    <key alias="userinviteExpiredMessage">Dobrodošli u Umbraco! Nažalost pozivnica je istekla. Molimo kontaktirajte svog administratora i od njega tražite da ju ponovno pošalje.</key>
+    <key alias="userinviteAvatarMessage">AAko postavite svoju fotografiju, drugi korisnici će vas lako prepoznati. Kliknite krug iznad da biste prenijeli svoju fotografiju.</key>
+    <key alias="writer">Pisac</key>
+    <key alias="change">Promjeni</key>
+    <key alias="yourProfile" version="7.0">Vaš profil</key>
+    <key alias="yourHistory" version="7.0">Vaša nedavna povijest</key>
+    <key alias="sessionExpires" version="7.0">Sesija ističe za</key>
+    <key alias="inviteUser">Pozovi korisnika</key>
+    <key alias="createUser">Kreiraj korisnika</key>
+    <key alias="sendInvite">Pošalji pozivnicu</key>
+    <key alias="backToUsers">Nazad na korisnike</key>
+    <key alias="inviteEmailCopySubject">Umbraco: Pozivnica</key>
+    <key alias="inviteEmailCopyFormat"><![CDATA[
+        <html>
+			<head>
+				<meta name='viewport' content='width=device-width'>
+				<meta http-equiv='Content-Type' content='text/html; charset=UTF-8'>
+			</head>
+			<body class='' style='font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; color: #392F54; line-height: 22px; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background: #1d1333; margin: 0; padding: 0;' bgcolor='#1d1333'>
+				<style type='text/css'> @media only screen and (max-width: 620px) {table[class=body] h1 {font-size: 28px !important; margin-bottom: 10px !important; } table[class=body] .wrapper {padding: 32px !important; } table[class=body] .article {padding: 32px !important; } table[class=body] .content {padding: 24px !important; } table[class=body] .container {padding: 0 !important; width: 100% !important; } table[class=body] .main {border-left-width: 0 !important; border-radius: 0 !important; border-right-width: 0 !important; } table[class=body] .btn table {width: 100% !important; } table[class=body] .btn a {width: 100% !important; } table[class=body] .img-responsive {height: auto !important; max-width: 100% !important; width: auto !important; } } .btn-primary table td:hover {background-color: #34495e !important; } .btn-primary a:hover {background-color: #34495e !important; border-color: #34495e !important; } .btn  a:visited {color:#FFFFFF;} </style>
+				<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;" bgcolor="#1d1333">
+					<tr>
+						<td style="font-family: sans-serif; font-size: 14px; vertical-align: top; padding: 24px;" valign="top">
+							<table style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+								<tr>
+									<td background="https://umbraco.com/umbraco/assets/img/application/logo.png" bgcolor="#1d1333" width="28" height="28" valign="top" style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+										<!--[if gte mso 9]> <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:30px;height:30px;"> <v:fill type="tile" src="https://umbraco.com/umbraco/assets/img/application/logo.png" color="#1d1333" /> <v:textbox inset="0,0,0,0"> <![endif]-->
+<div></div>
+<!--[if gte mso 9]> </v:textbox> </v:rect> <![endif]-->
+</td>
+<td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top"></td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+<table border='0' cellpadding='0' cellspacing='0' class='body' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #1d1333;' bgcolor='#1d1333'>
+<tr>
+<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'></td>
+<td class='container' style='font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; max-width: 560px; width: 560px; margin: 0 auto; padding: 10px;' valign='top'>
+<div class='content' style='box-sizing: border-box; display: block; max-width: 560px; margin: 0 auto; padding: 10px;'>
+<br>
+<table class='main' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; border-radius: 3px; background: #FFFFFF;' bgcolor='#FFFFFF'>
+<tr>
+<td class='wrapper' style='font-family: sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 50px;' valign='top'>
+<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;'>
+<tr>
+<td style='line-height: 24px; font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'>
+<h1 style='color: #392F54; font-family: sans-serif; font-weight: bold; line-height: 1.4; font-size: 24px; text-align: left; text-transform: capitalize; margin: 0 0 30px;' align='left'>
+															Pozdrav %0%,
+														</h1>
+<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+															Pozvani ste od <a href="mailto:%4%" style="text-decoration: underline; color: #392F54; -ms-word-break: break-all; word-break: break-all;">%1%</a> u Umbraco administraciju.
+														</p>
+<p style='color: #392F54; font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 15px;'>
+															Poruka od <a href="mailto:%1%" style="text-decoration: none; color: #392F54; -ms-word-break: break-all; word-break: break-all;">%1%</a>:
+															<br/>
+<em>%2%</em>
+</p>
+<table border='0' cellpadding='0' cellspacing='0' class='btn btn-primary' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; box-sizing: border-box;'>
+<tbody>
+<tr>
+<td align='left' style='font-family: sans-serif; font-size: 14px; vertical-align: top; padding-bottom: 15px;' valign='top'>
+<table border='0' cellpadding='0' cellspacing='0' style='border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;'>
+<tbody>
+<tr>
+<td style='font-family: sans-serif; font-size: 14px; vertical-align: top; border-radius: 5px; text-align: center; background: #35C786;' align='center' bgcolor='#35C786' valign='top'>
+<a href='%3%' target='_blank' rel='noopener' style='color: #FFFFFF; text-decoration: none; -ms-word-break: break-all; word-break: break-all; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; text-transform: capitalize; background: #35C786; margin: 0; padding: 12px 30px; border: 1px solid #35c786;'>
+																							Kliknite na ovaj link da prihvatite pozivnicu
+																						</a>
+</td>
+</tr>
+</tbody>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<p style='max-width: 400px; display: block; color: #392F54; font-family: sans-serif; font-size: 14px; line-height: 20px; font-weight: normal; margin: 15px 0;'>Ukoliko ne možete kliknuti na link, kopirajte i zalijepite ovaj URL u prozor vašeg pretraživača:</p>
+<table border='0' cellpadding='0' cellspacing='0'>
+<tr>
+<td style='-ms-word-break: break-all; word-break: break-all; font-family: sans-serif; font-size: 11px; line-height:14px;'>
+<font style="-ms-word-break: break-all; word-break: break-all; font-size: 11px; line-height:14px;">
+<a style='-ms-word-break: break-all; word-break: break-all; color: #392F54; text-decoration: underline; font-size: 11px; line-height:15px;' href='%3%'>%3%</a>
+</font>
+</td>
+</tr>
+</table>
+</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</table>
+<br><br><br>
+</div>
+</td>
+<td style='font-family: sans-serif; font-size: 14px; vertical-align: top;' valign='top'></td>
+</tr>
+</table>
+</body>
+</html>]]></key>
+    <key alias="defaultInvitationMessage">Ponovno slanje pozivnice...</key>
+    <key alias="deleteUser">Obriši korisnika</key>
+    <key alias="deleteUserConfirmation">Jeste li sigurni da želite obrisati ovaj korisnički račun?</key>
+    <key alias="stateAll">Sve</key>
+    <key alias="stateActive">Aktivan</key>
+    <key alias="stateDisabled">Onemogućen</key>
+    <key alias="stateLockedOut">Zaključan</key>
+    <key alias="stateApproved">Odobren</key>
+    <key alias="stateInvited">Pozvan</key>
+    <key alias="stateInactive">Neaktivan</key>
+    <key alias="sortNameAscending">Naziv (A-Z)</key>
+    <key alias="sortNameDescending">Naziv (Z-A)</key>
+    <key alias="sortCreateDateAscending">Najstarije</key>
+    <key alias="sortCreateDateDescending">Najnovije</key>
+    <key alias="sortLastLoginDateDescending">Zadnja prijava</key>
+    <key alias="noUserGroupsAdded">Nijedna korisnička grupa nije dodana</key>
+    <key alias="2faDisableText">Ako želite onemogućiti ovaj dvofaktorski provajder, onda morate unjeti kod prikazan na vašem uređaju za autentifikaciju:</key>
+    <key alias="2faProviderIsEnabled">Ovaj dvofaktorski provajder je omogućen</key>
+    <key alias="2faProviderIsDisabledMsg">Ovaj dvofaktorski provajder je sada onemogućen</key>
+    <key alias="2faProviderIsNotDisabledMsg">Nešto je pošlo po zlu s pokušajem da se onemogući ovaj dvofaktorski provajder</key>
+    <key alias="2faDisableForUser">Želite li onemogućiti ovaj dvofaktorski provajder za ovog korisnika?</key>
+  </area>
+  <area alias="validation">
+    <key alias="validation">Validacija</key>
+    <key alias="noValidation">Nema validacije</key>
+    <key alias="validateAsEmail">Potvrdi kao adresu e-pošte</key>
+    <key alias="validateAsNumber">Potvrdite kao broj</key>
+    <key alias="validateAsUrl">Potvrdi kao URL</key>
+    <key alias="enterCustomValidation">...ili unesite prilagođenu validaciju</key>
+    <key alias="fieldIsMandatory">Polje je obavezno</key>
+    <key alias="mandatoryMessage">Upišite prilagođenu poruku o grešci validacije (opcionalno)</key>
+    <key alias="validationRegExp">Upišite regularni izraz</key>
+    <key alias="validationRegExpMessage">Upišite prilagođenu poruku o grešci validacije (opcionalno)</key>
+    <key alias="minCount">Morate dodati najmanje</key>
+    <key alias="maxCount">možete jedino imati</key>
+    <key alias="addUpTo">Dodajte do</key>
+    <key alias="items">stavke</key>
+    <key alias="urls">URL-ovi</key>
+    <key alias="urlsSelected">Odabrani URL-ovi</key>
+    <key alias="itemsSelected">odabrane stavke</key>
+    <key alias="invalidDate">Nevažeći datum</key>
+    <key alias="invalidNumber">Nije broj</key>
+    <key alias="invalidNumberStepSize">Nije važeća brojčana veličina koraka</key>
+    <key alias="invalidEmail">Nevažeći email</key>
+    <key alias="invalidNull">Vrijednost ne može biti null</key>
+    <key alias="invalidEmpty">Vrijednost ne može biti prazna</key>
+    <key alias="invalidPattern">Vrijednost je nevažeća, ne odgovara ispravnom uzorku</key>
+    <key alias="customValidation">Prilagođena validacija</key>
+    <key alias="entriesShort"><![CDATA[Minimalno %0% unosa, potrebno <strong>%1%</strong> više.]]></key>
+    <key alias="entriesExceed"><![CDATA[Maksimalno %0% unosa, <strong>%1%</strong> previše.]]></key>
+    <key alias="entriesAreasMismatch">Zahtjevi za količinu sadržaja nisu ispunjeni za jedno ili više područja.</key>
+  </area>
+  <area alias="healthcheck">
+    <!-- The following keys get these tokens passed in:
+	     0: Current value
+		   1: Recommended value
+		   2: XPath
+		   3: Configuration file path
+	  -->
+    <key alias="checkSuccessMessage">Vrijednost je postavljena na preporučenu vrijednost: '%0%'.</key>
+    <key alias="checkErrorMessageDifferentExpectedValue">Očekivana vrijednost '%1%' za '%2%' u konfiguracijskoj datoteci '%3%', ali je pronađeno '%0%'.</key>
+    <key alias="checkErrorMessageUnexpectedValue">Pronađena neočekivana vrijednost '%0%' za '%2%' u konfiguracijskoj datoteci '%3%'.
+    </key>
+    <!-- The following keys get these tokens passed in:
+	     0: Current value
+		   1: Recommended value
+	  -->
+    <key alias="macroErrorModeCheckSuccessMessage">Makro greške su postavljene na '%0%'.</key>
+    <key alias="macroErrorModeCheckErrorMessage">Greške makroa su postavljene na '%0%' što će spriječiti potpuno učitavanje nekih ili svih stranica 
+	  na vašem sajtu ako postoje greške u makroima. Ako ovo ispravite, vrijednost će biti postavljena na '%1%'.
+    </key>
+    <!-- The following keys get these tokens passed in:
+	     0: Current value
+		   1: Recommended value
+		   2: Server version
+	  -->
+    <!-- The following keys get predefined tokens passed in that are not all the same, like above -->
+    <key alias="httpsCheckValidCertificate">Certifikat Vaše web stranice je važeći.</key>
+    <key alias="httpsCheckInvalidCertificate">Greška u validaciji certifikata: '%0%'</key>
+    <key alias="httpsCheckExpiredCertificate">SSL certifikat vaše web stranice je istekao.</key>
+    <key alias="httpsCheckExpiringCertificate">SSL certifikat vaše web stranice istjeće za %0% dana.</key>
+    <key alias="healthCheckInvalidUrl">Greška pri pinganju URL-a %0% - '%1%'</key>
+    <key alias="httpsCheckIsCurrentSchemeHttps">Trenutno %0% pregledavate stranicu koristeći HTTPS protokol.</key>
+    <key alias="httpsCheckConfigurationRectifyNotPossible">AppSetting 'Umbraco:CMS:Global:UseHttps' je postavljen na 'false' u
+      vašoj appSettings.json datoteci. Jednom kada pristupite ovoj stranici koristeći HTTPS protokol, to bi trebalo biti postavljeno na 'true'.
+    </key>
+    <key alias="httpsCheckConfigurationCheckResult">Postavka aplikacije 'Umbraco:CMS:Global:UseHttps' je postavljena na '%0%' u vašoj
+      appSettings.json datoteci, vaši kolačići su %1% označeni kao sigurni.
+    </key>
+    <!-- The following keys don't get tokens passed in -->
+    <key alias="compilationDebugCheckSuccessMessage">Način kompilacije otklanjanja grešaka je onemogućen.</key>
+    <key alias="compilationDebugCheckErrorMessage">Način kompilacije za otklanjanje grešaka je trenutno omogućen. Preporučuje se da se
+      onemogućite ovu postavku prije korištenja u produkciji.
+    </key>
+    <!-- The following keys get these tokens passed in:
+	    0: Path to the file not found
+  	-->
+    <!-- The following keys get these tokens passed in:
+	    0: Comma delimitted list of failed folder paths
+  	-->
+    <!-- The following keys get these tokens passed in:
+	    0: Comma delimitted list of failed folder paths
+  	-->
+    <key alias="umbracoApplicationUrlCheckResultTrue"><![CDATA[AppSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' je postavljen na <strong>%0%</strong>.]]></key>
+    <key alias="umbracoApplicationUrlCheckResultFalse">AppSetting 'Umbraco:CMS:WebRouting:UmbracoApplicationUrl' nije postavljen.</key>
+    <key alias="clickJackingCheckHeaderFound">
+      <![CDATA[Zaglavlje ili meta-tag <strong>X-Frame-Options</strong> koji se koristi za kontrolu da li neko mjesto može biti IFRAMED od strane drugog je pronađen.]]></key>
+    <key alias="clickJackingCheckHeaderNotFound">
+      <![CDATA[Zaglavlje ili meta-tag <strong>X-Frame-Options</strong> koji se koristi za kontrolu da li neko mjesto može biti IFRAMED od strane drugog nije pronađen.]]></key>
+    <key alias="noSniffCheckHeaderFound">
+      <![CDATA[Zaglavlje ili meta-tag <strong>X-Content-Type-Options</strong> koji se koristi za zaštitu od ranjivosti MIME sniffinga je pronađen.]]></key>
+    <key alias="noSniffCheckHeaderNotFound">
+      <![CDATA[Zaglavlje ili meta-tag <strong>X-Content-Type-Options</strong> koji se koristi za zaštitu od ranjivosti MIME sniffinga nije pronađen.]]></key>
+    <key alias="hSTSCheckHeaderFound">
+      <![CDATA[Zaglavlje <strong>Strict-Transport-Security</strong>, također poznat kao HSTS-header, je pronađen.]]></key>
+    <key alias="hSTSCheckHeaderNotFound">
+      <![CDATA[Zaglavlje <strong>Strict-Transport-Security</strong> nije pronađeno.]]></key>
+    <key alias="hSTSCheckHeaderFoundOnLocalhost">
+      <![CDATA[Zaglavlje <strong>Strict-Transport-Security</strong>, također poznat kao HSTS-header, je pronađen. <strong>Ovo zaglavlje ne bi trebalo biti prisutno na lokalnom hostu.</strong>]]>
+    </key>
+    <key alias="hSTSCheckHeaderNotFoundOnLocalhost">
+      <![CDATA[Zaglavlje <strong>Strict-Transport-Security</strong> nije pronađeno. Ovo zaglavlje ne bi trebalo biti prisutno na lokalnom hostu.]]>
+    </key>
+    <key alias="xssProtectionCheckHeaderFound"><![CDATA[Zaglavlje <strong>X-XSS-Protection</strong> je pronađeno.]]></key>
+    <key alias="xssProtectionCheckHeaderNotFound">
+      <![CDATA[Zaglavlje <strong>X-XSS-Protection</strong> nije pronađeno.]]></key>
+    <!-- The following key get these tokens passed in:
+	    0: Comma delimitted list of headers found
+  	-->
+    <key alias="excessiveHeadersFound">
+      <![CDATA[Pronađena su sljedeća zaglavlja koja otkrivaju informacije o tehnologiji web stranice: <strong>%0%</strong>.]]></key>
+    <key alias="excessiveHeadersNotFound">Nisu pronađena zaglavlja koja otkrivaju informacije o tehnologiji web stranice.
+    </key>
+    <key alias="smtpMailSettingsNotFound">U datoteci Web.config, system.net/mailsettings nije moguće pronaći.</key>
+    <key alias="smtpMailSettingsHostNotConfigured">U datoteci Web.config, system.net/mailsettings, host
+      nije konfiguriran.
+    </key>
+    <key alias="smtpMailSettingsConnectionSuccess">SMTP postavke su ispravno konfigurirane i usluga radi
+      kao što je očekivano.
+    </key>
+    <key alias="smtpMailSettingsConnectionFail">SMTP server konfiguriran sa hostom '%0%' i portom '%1%' ne može biti
+      dohvaćen. Provjerite jesu li SMTP postavke u datoteci Web.config, system.net/mailsettings ispravne.
+    </key>
+    <key alias="notificationEmailsCheckSuccessMessage">
+      <![CDATA[E-mail za obavještenje je postavljen na <strong>%0%</strong>.]]></key>
+    <key alias="notificationEmailsCheckErrorMessage">
+      <![CDATA[E-pošta za obavještenje je i dalje postavljena na zadanu vrijednost od <strong>%0%</strong>.]]></key>
+    <key alias="scheduledHealthCheckEmailBody">
+      <![CDATA[<html><body><p>Rezultati zakazanih Umbraco provjera zdravlja koji se pokreću na %0% na %1% su sljedeći:</p>%2%</body></html>]]></key>
+    <key alias="scheduledHealthCheckEmailSubject">Status provjere zdravlja Umbraco: %0%</key>
+    <key alias="checkGroup">Provjerite grupu</key>
+    <key alias="helpText">
+      <![CDATA[
+        <p>Provjera zdravlja procjenjuje različita područja vaše web lokacije u pogledu postavki najboljih praksi, konfiguracija, potencijalnih problema itd. Možete jednostavno riješiti probleme pritiskom na gumb.
+        Možete dodati svoje zdravstvene preglede, pogledajte <a href="https://docs.umbraco.com/umbraco-cms/extending/health-check" target="_blank" rel="noopener" class="btn-link -underline">dokumentaciju za više informacija</a> o prilagođenim zdravstvenim pregledima.</p>
+        ]]>
+    </key>
+  </area>
+  <area alias="redirectUrls">
+    <key alias="disableUrlTracker">Onemogući URL praćenje</key>
+    <key alias="enableUrlTracker">Omogući URL praćenje</key>
+    <key alias="originalUrl">Originalni URL</key>
+    <key alias="redirectedTo">Preusmjerno na</key>
+    <key alias="redirectUrlManagement">Preusmjeravanje URL-ova</key>
+    <key alias="panelInformation">Sljedeći URL-ovi preusmjeravaju na ovu stavku sadržaja:</key>
+    <key alias="noRedirects">Nisu napravljena nikakva preusmjeravanja</key>
+    <key alias="noRedirectsDescription">Kada se objavljena stranica preimenuje ili premjesti, preusmjeravanje će automatski biti
+       napravljeno na novu stranicu.
+    </key>
+    <key alias="redirectRemoved">Preusmjeravanje uklonjeno.</key>
+    <key alias="redirectRemoveError">Greška pri uklanjanju preusmjeravanja.</key>
+    <key alias="redirectRemoveWarning">Ovo će ukloniti preusmjeravanje</key>
+    <key alias="confirmDisable">Jeste li sigurni da želite onemogućiti praćenje URL-ovač?</key>
+    <key alias="disabledConfirm">URL praćenje je sada onemogućeno.</key>
+    <key alias="disableError">Greška pri onemogućavanju praćenja URL-ova, više informacija možete pronaći u vašem log zapisu.</key>
+    <key alias="enabledConfirm">URL praćenje je sada omogućeno.</key>
+    <key alias="enableError">Greška pri omogućavanju praćenja URL-ova, više informacija možete pronaći u vašem log zapisu.</key>
+  </area>
+  <area alias="emptyStates">
+    <key alias="emptyDictionaryTree">Nema stavki iz rječnika za odabir</key>
+  </area>
+  <area alias="textbox">
+    <key alias="characters_left"><![CDATA[<strong>%0%</strong> preostalo znakova.]]></key>
+    <key alias="characters_exceed"><![CDATA[Maksimalno %0% znakova, <strong>%1%</strong> previše.]]></key>
+  </area>
+  <area alias="recycleBin">
+    <key alias="contentTrashed">Sadržaj u otpadu s ID-om: {0} povezan je s originalnim nadređenim sadržajem s ID-om: {1}</key>
+    <key alias="mediaTrashed">Medij u otpadu s ID-om: {0} povezan je s originalnim nadređenim medijem s ID-om: {1}</key>
+    <key alias="itemCannotBeRestored">Nije moguće automatski vratiti ovu stavku</key>
+    <key alias="itemCannotBeRestoredHelpText">Ne postoji lokacija na kojoj se ova stavka može automatski vratiti. Možete ručno premjestiti stavku koristeći stablo ispod.
+    </key>
+    <key alias="wasRestored">je restauriran pod</key>
+  </area>
+  <area alias="relationType">
+    <key alias="direction">Smjer</key>
+    <key alias="parentToChild">Roditelj djetetu</key>
+    <key alias="bidirectional">Bidirectional</key>
+    <key alias="parent">Roditelj</key>
+    <key alias="child">Dijete</key>
+    <key alias="count">Broj</key>
+    <key alias="relation">Relacija</key>
+    <key alias="relations">Relacije</key>
+    <key alias="created">Kreirano</key>
+    <key alias="comment">Komentar</key>
+    <key alias="name">Naziv</key>
+    <key alias="noRelations">Nema relacija za ovu vrstu odnosa</key>
+    <key alias="tabRelationType">Tip relacije</key>
+    <key alias="tabRelations">Relacije</key>
+    <key alias="isDependency">Je zavisan</key>
+    <key alias="dependency">Da</key>
+    <key alias="noDependency">Ne</key>
+  </area>
+  <area alias="dashboardTabs">
+    <key alias="contentIntro">Početak rada</key>
+    <key alias="contentRedirectManager">Preusmjeravanje URL-ova</key>
+    <key alias="mediaFolderBrowser">Sadržaj</key>
+    <key alias="settingsWelcome">Dobrodošli</key>
+    <key alias="settingsExamine">Examine menadžment</key>
+    <key alias="settingsPublishedStatus">Status stranice</key>
+    <key alias="settingsModelsBuilder">Generator modela</key>
+    <key alias="settingsHealthCheck">Provjera zdravlja</key>
+    <key alias="settingsProfiler">Profilisanje</key>
+    <key alias="memberIntro">Početak rada</key>
+    <key alias="formsInstall">Instaliraj Umbraco Forms</key>
+  </area>
+  <area alias="visuallyHiddenTexts">
+    <key alias="goBack">Vrati se</key>
+    <key alias="activeListLayout">Aktivan raspored:</key>
+    <key alias="jumpTo">Skoči na</key>
+    <key alias="group">grupa</key>
+    <key alias="passed">prošao</key>
+    <key alias="warning">upozorenje</key>
+    <key alias="failed">neuspješno</key>
+    <key alias="suggestion">prijedlog</key>
+    <key alias="checkPassed">Provjera prošla</key>
+    <key alias="checkFailed">Provjera nije uspjela</key>
+    <key alias="openBackofficeSearch">Otvorite backoffice pretragu</key>
+    <key alias="openCloseBackofficeHelp">Otvori/Zatvori pomoć za backoffice</key>
+    <key alias="openCloseBackofficeProfileOptions">Opcije otvaranja/zatvaranja profila</key>
+    <key alias="assignDomainDescription">Postavite kulturu i imena hostova za %0%</key>
+    <key alias="createDescription">Kreirajte novi čvor ispod %0%</key>
+    <key alias="protectDescription">Postavite ograničenja pristupa uključena %0%</key>
+    <key alias="rightsDescription">Dozvole za postavljanje su uključene %0%</key>
+    <key alias="sortDescription">Promijenite redoslijed sortiranja za %0%</key>
+    <key alias="createblueprintDescription">Kreirajte predložak sadržaja na osnovu %0%</key>
+    <key alias="openContextMenu">Otvorite kontekstni meni za</key>
+    <key alias="currentLanguage">Trenutni jezik</key>
+    <key alias="switchLanguage">Prebaci jezik na</key>
+    <key alias="createNewFolder">Kreirajte novi folder</key>
+    <key alias="newPartialView">Parcijalni pogled</key>
+    <key alias="newPartialViewMacro">Makro za pracijalni prikaz</key>
+    <key alias="newMember">Član</key>
+    <key alias="newDataType">Tip podatka</key>
+    <key alias="redirectDashboardSearchLabel">Pretražite kontrolnu ploču za preusmjeravanje</key>
+    <key alias="userGroupSearchLabel">Pretražite odjeljak korisničke grupe</key>
+    <key alias="userSearchLabel">Pretražite odjeljak korisnika</key>
+    <key alias="createItem">Kreiraj stavku</key>
+    <key alias="create">Kreiraj</key>
+    <key alias="edit">Uredi</key>
+    <key alias="name">Naziv</key>
+    <key alias="addNewRow">Dodaj novi red</key>
+    <key alias="tabExpand">Pogledajte više opcija</key>
+    <key alias="searchOverlayTitle">Pogledajte više opcija</key>
+    <key alias="searchOverlayDescription">Potražite čvorove sadržaja, medijske čvorove itd. u backofficeu.</key>
+    <key alias="searchInputDescription">Kada su dostupni rezultati autodovršavanja, pritisnite strelice gore i dolje ili koristite
+      tipku tab i koristite tipku enter za odabir.
+    </key>
+    <key alias="path">Putanja:</key>
+    <key alias="foundIn">Pronađeno u</key>
+    <key alias="hasTranslation">Ima prijevod</key>
+    <key alias="noTranslation">Nedostaje prijevod</key>
+    <key alias="dictionaryListCaption">Stavke iz rječnika</key>
+    <key alias="contextMenuDescription">Odaberite jednu od opcija za uređivanje čvora.</key>
+    <key alias="contextDialogDescription">Izvršite akciju %0% na čvoru %1%.</key>
+    <key alias="addImageCaption">Dodajte opis slike</key>
+    <key alias="searchContentTree">Pretraži stablo sadržaja</key>
+    <key alias="maxAmount">Maksimalni iznos</key>
+  </area>
+  <area alias="references">
+    <key alias="tabName">Reference</key>
+    <key alias="DataTypeNoReferences">Ovaj tip podataka nema reference.</key>
+    <key alias="itemHasNoReferences">Ova stavka nema reference.</key>
+    <key alias="labelUsedByDocumentTypes">Koristi se u tipovima dokumenata</key>
+    <key alias="labelUsedByMediaTypes">Koristi se u tipovima medija</key>
+    <key alias="labelUsedByMemberTypes">Koristi se u tipovima članova</key>
+    <key alias="usedByProperties">Koristi</key>
+    <key alias="labelUsedItems">Stavke u upotrebi</key>
+    <key alias="labelUsedDescendants">Potomci u upotrebi</key>
+    <key alias="deleteWarning">Ova stavka ili njeni potomci se koriste. Brisanje može dovesti do neispravnih veza na vašoj web stranici.</key>
+    <key alias="unpublishWarning">Ova stavka ili njeni potomci se koriste. Poništavanje objavljivanja može dovesti do neispravnih veza na vašoj web stranici. Molimo poduzmite odgovarajuće radnje.</key>
+    <key alias="deleteDisabledWarning">Ova stavka ili njeni potomci se koriste. Stoga je brisanje onemogućeno.</key>
+    <key alias="listViewDialogWarning">Sljedeće stavke koje pokušavate %0% koriste drugi sadržaj.</key>
+  </area>
+  <area alias="logViewer">
+    <key alias="deleteSavedSearch">Obriši spremljene pretrage</key>
+    <key alias="logLevels">Razine loga</key>
+    <key alias="selectAllLogLevelFilters">Označi sve</key>
+    <key alias="deselectAllLogLevelFilters">Odznači sve</key>
+    <key alias="savedSearches">Spremljene pretrage</key>
+    <key alias="saveSearch">Spremi pretragu</key>
+    <key alias="saveSearchDescription">Unesite prijateljski naziv za vaš upit za pretragu</key>
+    <key alias="filterSearch">Filtriraj pretragu</key>
+    <key alias="totalItems">Ukupno</key>
+    <key alias="timestamp">Vrijeme</key>
+    <key alias="level">Razina</key>
+    <key alias="machine">Uređaj</key>
+    <key alias="message">Poruka</key>
+    <key alias="exception">Izuzetak</key>
+    <key alias="properties">Svojstva</key>
+    <key alias="searchWithGoogle">Pretraži pomoću Google-a</key>
+    <key alias="searchThisMessageWithGoogle">Pretraži ovu poruku pomoću Google-a</key>
+    <key alias="searchWithBing">Pretraži pomoću Bing-a</key>
+    <key alias="searchThisMessageWithBing">Pretraži ovu poruku pomoću Bing-a</key>
+    <key alias="searchOurUmbraco">Pretraži Our Umbraco</key>
+    <key alias="searchThisMessageOnOurUmbracoForumsAndDocs">Pretraži ovu poruku na Our Umbraco forumu i dokumentaciji</key>
+    <key alias="searchOurUmbracoWithGoogle">Pretraži Our Umbraco pomoću Google-a</key>
+    <key alias="searchOurUmbracoForumsUsingGoogle">Pretraži Our Umbraco forume pomoću Google-a</key>
+    <key alias="searchUmbracoSource">Pretraži Umbraco Source</key>
+    <key alias="searchWithinUmbracoSourceCodeOnGithub">Pretraži Umbraco source code on Github-u</key>
+    <key alias="searchUmbracoIssues">Pretraži Umbraco Issues</key>
+    <key alias="searchUmbracoIssuesOnGithub">Pretraži Umbraco Issues na Github-u</key>
+    <key alias="deleteThisSearch">Obriši ovu pretragu</key>
+    <key alias="findLogsWithRequestId">Pronađi logove sa ID-om zatjeva</key>
+    <key alias="findLogsWithNamespace">Pronađi logove sa namespace-om</key>
+    <key alias="findLogsWithMachineName">Pronađi logove sa nazivom uređaja</key>
+    <key alias="open">Otvori</key>
+    <key alias="polling">Provjera</key>
+    <key alias="every2">Svakih 2 sekunde</key>
+    <key alias="every5">Svakih 5 sekundi</key>
+    <key alias="every10">Svakih 10 sekundi</key>
+    <key alias="every20">Svakih 20 sekundi</key>
+    <key alias="every30">Svakih 30 sekundi</key>
+    <key alias="pollingEvery2">Provjera svakih 2s</key>
+    <key alias="pollingEvery5">Provjera svakih 5s</key>
+    <key alias="pollingEvery10">Provjera svakih 10s</key>
+    <key alias="pollingEvery20">Provjera svakih 20s</key>
+    <key alias="pollingEvery30">Provjera svakih 30s</key>
+  </area>
+  <area alias="clipboard">
+    <key alias="labelForCopyAllEntries">Kopiraj %0%</key>
+    <key alias="labelForArrayOfItemsFrom">%0% od %1%</key>
+    <key alias="labelForArrayOfItems">Zbirka od %0%</key>
+    <key alias="labelForRemoveAllEntries">Uklonite sve stavke</key>
+    <key alias="labelForClearClipboard">Očisti međuspremnik</key>
+  </area>
+  <area alias="propertyActions">
+    <key alias="tooltipForPropertyActionsMenu">Otvorite radnje svojstva</key>
+    <key alias="tooltipForPropertyActionsMenuClose">Zatvorite Property Actions</key>
+  </area>
+  <area alias="nuCache">
+    <key alias="refreshStatus">Osvježi status</key>
+    <key alias="memoryCache">Predmemorija</key>
+    <key alias="memoryCacheDescription">
+      <![CDATA[
+            Ovaj gumb vam omogućuje da obnovite predmemoriju tako što ćete je u potpunosti ponovo učitati iz baze podataka
+    (ali ne obnavlja predmemoriju baze podataka). Ovo je relativno brzo.
+    Koristite ga kada mislite da predmemorija nije pravilno osvježena, nakon nekih događaja
+    pokrenuo&mdash;što bi ukazivalo na manji problem sa Umbracom.
+    (Napomena: pokreće ponovno učitavanje na svim serverima u LB okruženju).
+    ]]>
+    </key>
+    <key alias="reload">Ponovo učitaj</key>
+    <key alias="databaseCache">Predmemorija baze podataka</key>
+    <key alias="databaseCacheDescription">
+      <![CDATA[
+    Ovaj gumb vam omogućuje da ponovo obnovite predmemoriju baze podataka, tj. sadržaj tabele cmsContentNu.
+    <strong>Obnova može biti skupa.</strong>
+    Koristite ga kada ponovno učitavanje nije dovoljno, a mislite da predmemorija baze podataka nije bila
+    pravilno generirana; što bi ukazivalo na neko kritično pitanje Umbraco.
+    ]]>
+    </key>
+    <key alias="rebuild">Ponovo obnovi</key>
+    <key alias="internals">Unutrašnjost</key>
+    <key alias="internalsDescription">
+      <![CDATA[
+    Ovaj gumb vam omogućuje da pokrenete kolekciju NuCache snimaka (nakon pokretanja fullCLR GC-a).
+    Osim ako ne znate šta to znači, vjerovatno ga <em>ne</em> morate koristiti.
+    ]]>
+    </key>
+    <key alias="collect">Skupiti</key>
+    <key alias="publishedCacheStatus">Objavljeni status predmemorije</key>
+    <key alias="caches">Predmemorije</key>
+  </area>
+  <area alias="profiling">
+    <key alias="performanceProfiling">Profiliranje performansi</key>
+    <key alias="performanceProfilingDescription">
+      <![CDATA[
+            <p>
+               Umbraco trenutno radi u načinu za otklanjanje grešaka. To znači da možete koristiti ugrađeni profiler performansi za procjenu performansi prilikom renderiranja stranica.
+            </p>
+            <p>
+                Ako želite aktivirati profiler za određeno prikazivanje stranice, jednostavno dodajte <strong>umbDebug=true</strong> na string upita kada tražite stranicu.
+            </p>
+            <p>
+                Ako želite da se profilator aktivira prema zadanim postavkama za sve prikaze stranica, možete koristiti prekidač ispod.
+                On će postaviti kolačić u vaš pretraživač, koji zatim automatski aktivira profiler.
+                Drugim riječima, profiler će biti aktivan samo po defaultu u <em>vašen</em> pretraživaču.
+            </p>
+    ]]>
+    </key>
+    <key alias="activateByDefault">Zadano aktivirajte profiler</key>
+    <key alias="reminder">Prijateljski podsjetnik</key>
+    <key alias="reminderDescription">
+      <![CDATA[
+        <p>
+            Nikada ne bi trebali dozvoliti da produkcijska lokacija radi u načinu za otklanjanje grešaka. Režim za otklanjanje grešaka se isključuje podešavanjem <strong>Umbraco:CMS:Hosting:Debug</strong> na <strong>false</strong> u appsettings.json, appsettings.{Environment}.json ili preko varijable okruženja.
+        </p>
+    ]]>
+    </key>
+    <key alias="profilerEnabledDescription">
+      <![CDATA[
+        <p>
+            Umbraco trenutno ne radi u načinu za otklanjanje grešaka, tako da ne možete koristiti ugrađeni profiler. Ovako bi trebalo da bude za proizvodnu lokaciju.
+        </p>
+        <p>
+            Režim za otklanjanje grešaka se uključuje podešavanjem <strong>Umbraco:CMS:Hosting:Debug</strong> na <strong>true</strong> u appsettings.json, appsettings.{Environment}.json ili preko varijable okruženja.
+        </p>
+    ]]>
+    </key>
+  </area>
+  <area alias="settingsDashboardVideos">
+    <key alias="trainingHeadline">Sati Umbraco trening videa udaljeni su samo jedan klik</key>
+    <key alias="trainingDescription">
+      <![CDATA[
+            <p>Želite naučiti Umbraco? Provedite nekoliko minuta učeći najbolje prakse gledajući jedan od ovih videozapisa o korištenju Umbraco-a. I posjetite <a href="https://umbraco.tv" target="_blank" rel="noopener">umbraco.tv</a> za još više Umbraco videa</p>
+        ]]>
+    </key>
+    <key alias="learningBaseDescription">
+      <![CDATA[
+        <p>Želite savladati Umbraco? Provedite nekoliko minuta učeći najbolje prakse gledajući jedan od ovih videozapisa o korištenju Umbraco-a <a href="https://www.youtube.com/c/UmbracoLearningBase" target="_blank" rel="noopener"> Umbraco Learning Base Youtube kanal</a>. Ovdje možete pronaći gomilu video materijala koji pokriva mnoge aspekte Umbraco-a.</p>
+      ]]>
+    </key>
+    <key alias="getStarted">Za početak</key>
+  </area>
+  <area alias="settingsDashboard">
+    <key alias="start">Počni ovdje</key>
+    <key alias="startDescription">Ovaj odjeljak sadrži blokove za izgradnju vaše Umbraco stranice. Slijedite dolje
+      veze da saznate više o radu sa stavkama u odjeljku Postavke
+    </key>
+    <key alias="more">Saznajte više</key>
+    <key alias="bulletPointOne">
+      <![CDATA[
+        Pročitajte više o radu sa stavkama u Postavkama <a class="btn-link -underline" href="https://docs.umbraco.com/umbraco-cms/fundamentals/backoffice/sections/" target="_blank" rel="noopener">u odjeljku Dokumentacija</a> na Our Umbraco
+    ]]>
+    </key>
+    <key alias="bulletPointTwo">
+      <![CDATA[
+        Postavite pitanje na <a class="btn-link -underline" href="https://our.umbraco.com/forum" target="_blank" rel="noopener">Forumu zajednice</a>
+    ]]>
+    </key>
+    <key alias="bulletPointTutorials">
+      <![CDATA[
+        Gledajte besplatno <a class="btn-link -underline" href="https://umbra.co/ulb" target="_blank" rel="noopener">video tutorijale na Umbraco Learning Base</a>
+    ]]>
+    </key>
+    <key alias="bulletPointFour">
+      <![CDATA[
+        Saznajte više o našim <a class="btn-link -underline" href="https://umbraco.com/products/" target="_blank" rel="noopener">alatima za povećanje produktivnosti i komercijalna podrška</a>
+    ]]>
+    </key>
+    <key alias="bulletPointFive">
+      <![CDATA[
+        Saznajte nešto o mogućnosti stvarne <a class="btn-link -underline" href="https://umbraco.com/training/" target="_blank" rel="noopener">obuke i certifikacije</a>
+    ]]>
+    </key>
+  </area>
+  <area alias="startupDashboard">
+    <key alias="fallbackHeadline">Dobrodošli u The Friendly CMS</key>
+    <key alias="fallbackDescription">Hvala vam što ste odabrali Umbraco - mislimo da bi ovo mogao biti početak nečeg divnog. Iako se u početku može činiti neodoljivim, učinili smo puno da učenje bude što lakše i brže što je moguće više.
+    </key>
+  </area>
+  <area alias="formsDashboard">
+    <key alias="formsHeadline">Umbraco Forms</key>
+    <key alias="formsDescription">Kreirajte obrasce pomoću intuitivnog 'drag and drop' sučelja. Od jednostavnih kontakt obrazaca
+       koji šalje e-mailove do naprednih obrazaca koji se mogu integrirati sa CRM sustavima. Vašim klijentima će se svidjeti!
+    </key>
+  </area>
+  <area alias="blockEditor">
+    <key alias="headlineCreateBlock">Odaberite tip elementa</key>
+    <key alias="headlineAddSettingsElementType">Priložite postavke na tip elementa</key>
+    <key alias="headlineAddCustomView">Odaberite prikaz</key>
+    <key alias="headlineAddCustomStylesheet">Odaberite stil</key>
+    <key alias="headlineAddThumbnail">Odaberite sličicu</key>
+    <key alias="labelcreateNewElementType">Kreirajte novi tip elementa</key>
+    <key alias="labelCustomStylesheet">Prilagođeni stil</key>
+    <key alias="addCustomStylesheet">Dodaj stil</key>
+    <key alias="headlineEditorAppearance">Izgled bloka</key>
+    <key alias="headlineDataModels">Modeli podataka</key>
+    <key alias="headlineCatalogueAppearance">Izgled kataloga</key>
+    <key alias="labelBackgroundColor">Boja pozadine</key>
+    <key alias="labelIconColor">Boja ikone</key>
+    <key alias="labelContentElementType">Model sadržaja</key>
+    <key alias="labelLabelTemplate">Oznaka</key>
+    <key alias="labelCustomView">Prilagođeni prikaz</key>
+    <key alias="labelCustomViewInfoTitle">Prikaži opis prilagođenog prikaza</key>
+    <key alias="labelCustomViewDescription">Zamjenite način na koji se ovaj blok pojavljuje u korisničkom sučelju backofficea. Odaberite .html datoteku
+      koja sadrži vaš dizajn.
+    </key>
+    <key alias="labelSettingsElementType">Model postavki</key>
+    <key alias="labelEditorSize">Veličina uređivača preklapanja</key>
+    <key alias="addCustomView">Dodaj prilagođeni prikaz</key>
+    <key alias="addSettingsElementType">Dodaj postavke</key>
+    <key alias="confirmDeleteBlockMessage">
+      <![CDATA[Jeste li sigurni da želite obrisati sadržaj <strong>%0%</strong>?]]></key>
+    <key alias="confirmDeleteBlockTypeMessage">
+      <![CDATA[Jeste li sigurni da želite obrisati konfiguraciju bloka <strong>%0%</strong>?]]></key>
+    <key alias="confirmDeleteBlockTypeNotice">Sadržaj ovog bloka bit će i dalje prisutan, uređivanje ovog sadržaja
+      više neće biti dostupno i bit će prikazan kao nepodržani sadržaj.
+    </key>
+    <key alias="confirmDeleteBlockGroupMessage">
+      <![CDATA[Jeste li sigurni da želite obrisati grupu <strong>%0%</strong> i sve konfiguracije ovog bloka?]]></key>
+    <key alias="confirmDeleteBlockGroupNotice">Sadržaj ovih blokova će i dalje biti prisutan, uređivanje ovog sadržaja
+      više neće biti dostupan i bit će prikazan kao nepodržani sadržaj.
+    </key>
+    <key alias="blockConfigurationOverlayTitle"><![CDATA[Konfiguracija od '%0%']]></key>
+    <key alias="elementTypeDoesNotExist">Ne može se uređivati jer tip elementa ne postoji.</key>
+    <key alias="thumbnail">Sličica</key>
+    <key alias="addThumbnail">Dodaj sličicu</key>
+    <key alias="tabCreateEmpty">Kreiraj prazno</key>
+    <key alias="tabClipboard">Međuspremnik</key>
+    <key alias="tabBlockSettings">Postavke</key>
+    <key alias="headlineAdvanced">Napredno</key>
+    <key alias="forceHideContentEditor">Sakrij uređivač sadržaja</key>
+    <key alias="forceHideContentEditorHelp">Sakrij gumb za uređivanje sadržaja i uređivač sadržaja iz preklapanja Block Editor.</key>
+    <key alias="girdInlineEditing">Inline uređivanje</key>
+    <key alias="girdInlineEditingHelp">Omogućava inline uređivanje za prvo svojstvo. Dodatna svojstva se mogu uređivati u prekrivaču.</key>
+    <key alias="blockHasChanges">Izmijenili ste ovaj sadržaj. Jeste li sigurni da ih želite odbaciti?</key>
+    <key alias="confirmCancelBlockCreationHeadline">Odbaciti kreiranje?</key>
+    <key alias="confirmCancelBlockCreationMessage"><![CDATA[Jeste li sigurni da želite otkazati kreiranje.]]></key>
+    <key alias="elementTypeDoesNotExistHeadline">Greška!</key>
+    <key alias="elementTypeDoesNotExistDescription">Tip elementa ovog bloka više ne postoji</key>
+    <key alias="addBlock">Dodaj sadržaj</key>
+    <key alias="addThis">Dodaj %0%</key>
+    <key alias="propertyEditorNotSupported">Svojstvo '%0%' koristi uređivač '%1%' koji nije podržan u blokovima.</key>
+    <key alias="focusParentBlock">Postavite fokus na blok kontejnera</key>
+    <key alias="areaIdentification">Identifikacija</key>
+    <key alias="areaValidation">Validacija</key>
+    <key alias="areaValidationEntriesShort"><![CDATA[<strong>%0%</strong> mora biti prisutan barem <strong>%2%</strong> puta.]]></key>
+    <key alias="areaValidationEntriesExceed"><![CDATA[<strong>%0%</strong> mora biti maksimalno prisutan <strong>%3%</strong> puta.]]></key>
+    <key alias="areaNumberOfBlocks">Broj blokova</key>
+    <key alias="areaDisallowAllBlocks">Dozvolite samo određene tipove blokova</key>
+    <key alias="areaAllowedBlocks">Dozvoljene vrste blokova</key>
+    <key alias="areaAllowedBlocksHelp">Definirajte tipove blokova koji su dozvoljeni u ovom području i opcionalo koliko svakog tipa treba biti prisutan.</key>
+    <key alias="confirmDeleteBlockAreaMessage">Jeste li sigurni da želite obrisati ovo područje?</key>
+    <key alias="confirmDeleteBlockAreaNotice">Svi blokovi koji su trenutno kreirani unutar ovog područja bit će obrisani.</key>
+    <key alias="layoutOptions">Opcije rasporeda</key>
+    <key alias="structuralOptions">Strukturno</key>
+    <key alias="sizeOptions">Opcije veličine</key>
+    <key alias="sizeOptionsHelp">Definirajte jednu ili više opcija veličine, ovo omogućava promjenu veličine bloka</key>
+    <key alias="allowedBlockColumns">Definirajte jednu ili više opcija veličine, ovo omogućava promjenu veličine bloka</key>
+    <key alias="allowedBlockColumnsHelp">Definirajte različit broj kolona preko kojih ovaj blok može se protezati. Ovo ne sprječava postavljanje blokova u područja s manjim rasponom kolona.</key>
+    <key alias="allowedBlockRows">Dostupni rasponi redova</key>
+    <key alias="allowedBlockRowsHelp">Definirajte raspon redova rasporeda preko kojih se ovaj blok može protezati.</key>
+    <key alias="allowBlockInRoot">Dozvolite u korijenu</key>
+    <key alias="allowBlockInRootHelp">Učinite ovaj blok dostupnim u korijenu izgleda.</key>
+    <key alias="allowBlockInAreas">Dozvolite u područjima</key>
+    <key alias="allowBlockInAreasHelp">Učinite ovaj blok dostupnim prema zadanim postavkama unutar područja drugih blokova (osim ako za ova područja nisu postavljene eksplicitne dozvole).</key>
+    <key alias="areaAllowedBlocksEmpty">Prema zadanim postavkama, svi tipovi blokova su dozvoljeni u području. Koristite ovu opciju da dozvolite samo odabrane tipove.</key>
+    <key alias="areas">Područja</key>
+    <key alias="areasLayoutColumns">Mrežne kolone za područja</key>
+    <key alias="areasLayoutColumnsHelp">Definirajte koliko će stupaca biti dostupno za područja. Ako nije definiran, koristit će se broj kolona definiranih za cijeli izgled.</key>
+    <key alias="areasConfigurations">Područja</key>
+    <key alias="areasConfigurationsHelp">Da biste omogućili ugniježđenje blokova unutar ovog bloka, definirajte jedno ili više područja. Područja slijede raspored definiran njihovom vlastitom konfiguracijom stupca mreže. 'Raspon kolone' i 'raspon reda' za svako područje može se podesiti korištenjem okvira za rukovanje skalom u donjem desnom uglu odabranog područja.</key>
+    <key alias="invalidDropPosition"><![CDATA[<strong>%0%</strong> nije dozvoljeno na ovom mjestu.]]></key>
+    <key alias="defaultLayoutStylesheet">Zadani raspored stilova</key>
+    <key alias="confirmPasteDisallowedNestedBlockHeadline">Nedozvoljeni sadržaj je odbijen</key>
+    <key alias="confirmPasteDisallowedNestedBlockMessage">
+      <![CDATA[Umetnuti sadržaj sadržavao je nedozvoljeni sadržaj koji nije kreiran. Želite li ipak zadržati ostatak ovog sadržaja??]]></key>
+    <key alias="areaAliasHelp">
+      <![CDATA[Kada koristite GetBlockGridHTML() za prikazivanje Block Grid-a, alias će biti prikazan u oznaci kao 'data-area-alias' atribut. Koristite atribut alias za ciljanje elementa za područje. Npr. .umb-block-grid__area[data-area-alias="MyAreaAlias"] { ... }]]></key>
+    <key alias="scaleHandlerButtonTitle">Povucite za povečanje</key>
+    <key alias="areaCreateLabelTitle">Kreiraj oznaku gumba</key>
+    <key alias="areaCreateLabelHelp">Nadjačajte tekst oznake za dodavanje novog bloka u ovo područje, primjer: 'Dodaj widget'</key>
+    <key alias="showSizeOptions">Prikaži opcije promjene veličine</key>
+    <key alias="addBlockType">Dodaj blok</key>
+    <key alias="addBlockGroup">Dodaj grupu</key>
+    <key alias="pickSpecificAllowance">Odaberi grupu ili blok</key>
+    <key alias="allowanceMinimum">Postavite minimalni zahtjev</key>
+    <key alias="allowanceMaximum">Postavite maksimalan zahtjev</key>
+    <key alias="block">Blok</key>
+    <key alias="tabBlock">Blok</key>
+    <key alias="tabBlockTypeSettings">Postavke</key>
+    <key alias="tabAreas">Područja</key>
+    <key alias="tabAdvanced">Napredno</key>
+    <key alias="headlineAllowance">Dozvole</key>
+    <key alias="getSampleHeadline">Instalirajte uzorak konfiguracije</key>
+    <key alias="getSampleDescription"><![CDATA[Ovo će dodati osnovne blokove i pomoći vam da započnete s Block Grid Editorom. Dobit ćete blokove za naslov, obogaćeni tekst, sliku, kao i raspored u dvije kolone.]]></key>
+    <key alias="getSampleButton">Instaliraj</key>
+    <key alias="actionEnterSortMode">Način sortiranja</key>
+    <key alias="actionExitSortMode">Završi način sortiranja</key>
+    <key alias="areaAliasIsNotUnique">Ovaj alias područja mora biti jedinstven u usporedbi sa drugim područjima ovog bloka.</key>
+    <key alias="configureArea">Konfiguriraj područje</key>
+    <key alias="deleteArea">Obriši područje</key>
+    <key alias="addColumnSpanOption">Dodajte opciju raspona %0% kolona</key>
+  </area>
+  <area alias="contentTemplatesDashboard">
+    <key alias="whatHeadline">Što su predlošci sadržaja?</key>
+    <key alias="whatDescription">Predlošci sadržaja su unaprijed definirani sadržaj koji se može odabrati prilikom kreiranja novog
+      sadržaj čvora.
+    </key>
+    <key alias="createHeadline">Kako da kreiram predložak sadržaja?</key>
+    <key alias="createDescription">
+      <![CDATA[
+            <p>Postoje dva načina za kreiranje predloška sadržaja:</p>
+            <ul>
+                <li>Desnom tipkom miša kliknite čvor sadržaja i odaberite "Kreiraj predložak sadržaja" da bi kreirali novi predložak sadržaja.</li>
+                <li>Kliknite desnom tipkom miša na stablo predložaka sadržaja u odjeljku Postavke i odaberite vrstu dokumenta za koju želite kreirati predložak sadržaja.</li>
+            </ul>
+            <p>Nakon što upišete ime, urednici mogu početi koristiti predložak sadržaja kao osnovu za svoju novu stranicu.</p>
+        ]]>
+    </key>
+    <key alias="manageHeadline">Kako upravljati predlošcima sadržaja?</key>
+    <key alias="manageDescription">Možete uređivati i brisati predloške sadržaja iz stabla "Predlošci sadržaja" u
+      sekciji postavke. Proširite vrstu dokumenta na kojoj se temelji predložak sadržaja i kliknite na nju da biste uredili ili obrisali.
+    </key>
+  </area>
+  <area alias="preview">
+    <key alias="endLabel">Kraj</key>
+    <key alias="endTitle">Završi način pregleda</key>
+    <key alias="openWebsiteLabel">Pregledajte web stranicu</key>
+    <key alias="openWebsiteTitle">Otvorite web stranicu u načinu pregleda</key>
+    <key alias="returnToPreviewHeadline">Pregledajte web stranicu?</key>
+    <key alias="returnToPreviewDescription">Završili ste način pregleda, želite li ga ponovo omogućiti da vidite
+      najnovije spremljene verzije vaše web stranice?
+    </key>
+    <key alias="returnToPreviewAcceptButton">Pregledajte najnoviju verziju</key>
+    <key alias="returnToPreviewDeclineButton">Pogledajte objavljenu verziju</key>
+    <key alias="viewPublishedContentHeadline">Pogledajte objavljenu verziju?</key>
+    <key alias="viewPublishedContentDescription">Nalazite se u načinu pregleda, želite li izaći da biste vidjeli
+      objavljenu verziju Vaše web stranice?
+    </key>
+    <key alias="viewPublishedContentAcceptButton">Pogledajte objavljenu verziju</key>
+    <key alias="viewPublishedContentDeclineButton">Ostanite u načinu pregleda</key>
+  </area>
+  <area alias="permissions">
+    <key alias="FolderCreation">Kreiranje mape</key>
+    <key alias="FileWritingForPackages">Pisanje datoteka za pakete</key>
+    <key alias="FileWriting">Pisanje datoteka</key>
+    <key alias="MediaFolderCreation">Kreiranje medijskog foldera</key>
+  </area>
+  <area alias="treeSearch">
+    <key alias="searchResult">stavka vraćena</key>
+    <key alias="searchResults">stavke vraćene</key>
+  </area>
+</language>


### PR DESCRIPTION
Croatian language translation of Umbraco backoffice and culture settings. This language can be tested by changing language to Croatian on the user account page.

![picture1](https://github.com/alevak09/Umbraco-CMS/assets/73195407/02cdd522-aaf4-4080-8449-b08b1017d43c)
![prcture2](https://github.com/alevak09/Umbraco-CMS/assets/73195407/d525d63e-bf35-468f-8176-cac0b8a6219d)
![picture3](https://github.com/alevak09/Umbraco-CMS/assets/73195407/4453d019-3c7c-4c70-88a6-d7849383d4ec)
